### PR TITLE
Add option to calculate baselines based on USGS absolutes data

### DIFF
--- a/magpy/absolutes.py
+++ b/magpy/absolutes.py
@@ -49,6 +49,7 @@ from magpy.database import *
 from magpy.transfer import *
 
 import dateutil.parser as dparser
+import urllib2
 
 MAGPY_SUPPORTED_ABSOLUTES_FORMATS = ['MAGPYABS','MAGPYNEWABS','AUTODIF','JSONABS','UNKNOWN']
 ABSKEYLIST = ['time', 'hc', 'vc', 'res', 'f', 'mu', 'md', 'expectedmire', 'varx', 'vary', 'varz', 'varf', 'var1', 'var2']
@@ -152,6 +153,8 @@ class DILineStruct(object):
             headers['analysisdate'] = self.inputdate
 
         # The order needs to be changed according to the file list
+
+
         for i, elem in enumerate(self.time):
             if 4 <= i < 12 or 16 <= i < 25:
                 row = AbsoluteDIStruct()
@@ -313,22 +316,24 @@ class AbsoluteData(object):
         """
         DEFINITION:
             check whether variometer/scalar data is available for each time step
-            of DI data (within 2* samplingrate diff 
+            of DI data (within 2* samplingrate diff
         """
         # 1. Drop all data without value
         samprate = datastream.samplingrate()
         for key in keys:
             datastream = datastream._drop_nans(key)
         if not datastream.length()[0] > 1:
-            return False        
+            return False
         # 2. Get time column
         timea = np.asarray(datastream._get_column('time'))
+
         # 3. Get time column of DI data
         timeb = np.asarray([el.time for el in self])
         # 4. search
         #print(len(timea), len(timeb), samprate)
         #print(timea, timeb)
         indtia = [idx for idx, el in enumerate(timeb) if np.min(np.abs(timea-float(el)))/(samprate/24./3600.)*2 <= 1.]
+
         if not len(indtia) == len(timeb):
             return False
 
@@ -792,7 +797,7 @@ class AbsoluteData(object):
         #     1. check Absolute file - no delta F -> use delta F from abs file
         #     2. check Scalar path
         #     3. check provided annual means
-        #     4. TODO basevalue is calculated at time t0 
+        #     4. TODO basevalue is calculated at time t0
         #        -> According to Juerges excel sheet only D is determined at t0
         #        -> I and F are averages within time range of DI meas
         # ###################################
@@ -1008,7 +1013,7 @@ class AbsoluteData(object):
         EZI3 = EZI3/2.
 
         i1list = [np.abs(elem) for elem in i1list]
-          
+
         #print "Collimation", S0I1, S0I2, S0I3, EZI1, EZI2, EZI3
         # Variometer correction to start time is missing for f value and inc ???
         inc = np.mean(i1list)*180.0/np.pi + deltaI
@@ -1204,7 +1209,7 @@ class AbsoluteData(object):
             - scalevalue:       (list of floats) scalevalues for each component (e.g. default = [1,1,1])
             - debugmode:        (bool) activate additional debug output -- !!!!!!! removed and replaced by loggin !!!!!
             - printresults      (bool) - if True print results to screen
-            - meantime          (bool) if true, values are recalculated to nearest 
+            - meantime          (bool) if true, values are recalculated to nearest
                                        horizontal measurement to average time
 
         USED BY:
@@ -1572,6 +1577,8 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
 
     varioid = 'Unknown'
     scalarid = 'Unknown'
+
+
     # ####################################
     # 2. Get absolute data
     # ####################################
@@ -1613,6 +1620,7 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
             print("absoluteAnalysis:  getting DI data from files")
             pass
 
+
     if readfile:
         # Get list of files
         if isinstance(absdata, basestring):
@@ -1620,6 +1628,8 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
             #filelist.append(absdata)
             if "://" in absdata:
                 print("Found URL code - requires name of data set with date")
+                if "observation.json" in absdata:
+                    dataformat = 'JSONABS'
                 filelist.append(absdata)
                 movetoarchive = False # XXX No archiving function supported so far - will be done as soon as writing to files is available
             elif os.path.isfile(absdata):
@@ -1639,7 +1649,9 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
                 #print "Found List"
                 listlen = len(absdata)
                 for elem in absdata:
-                    if "://" in absdata:
+                    if "://" in elem:
+                        if "observation.json" in elem:
+                            dataformat = 'JSONABS'
                         print("Found URL code - requires name of data set with date")
                         filelist.append(elem)
                         movetoarchive = False # XXX No archiving function supported so far - will be done as soon as writing to files is available
@@ -1652,19 +1664,19 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
 
         for elem in filelist:
             head, tail = os.path.split(elem)
-            try:
-                date = dparser.parse(tail,fuzzy=True)
-                datelist.append(datetime.strftime(date,"%Y-%m-%d"))
-            except:
+            if "starttime=" in elem:
+                pos = elem.find("starttime=")+10
+                epos = pos + 10
+                datelist += [elem[pos:epos]]
+            if len(datelist) == 0:
                 try:
-                    date = dparser.parse(tail[:19],fuzzy=True)
+                    date = dparser.parse(tail,fuzzy=True)
                     datelist.append(datetime.strftime(date,"%Y-%m-%d"))
                 except:
                     print("absoluteAnalysis: Found date problem in file: %s" % tail)
                     failinglist.append(elem)
 
         datelist = list(set(datelist))
-
 
     datetimelist = [datetime.strptime(elem,'%Y-%m-%d') for elem in datelist]
 
@@ -1673,7 +1685,6 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
         datetimelist = [elem for elem in datetimelist if elem >= empty._testtime(starttime)]
     if endtime:
         datetimelist = [elem for elem in datetimelist if elem <= empty._testtime(endtime)]
-
     if not len(datetimelist) > 0:
         print("absoluteAnalysis: No matching dates found - aborting")
         return
@@ -1699,14 +1710,24 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
         try:
             valalpha = ''
             valbeta = ''
-            variodbtest = variodata.split(',')
+            if not "elements=" in variodata:
+                variodbtest = variodata.split(',')
+            else:
+                variodbtest = [variodata]
+            if "starttime=" in variodata:
+                parsed = variodata.split('&')
+                parsed = [el for el in parsed if not "starttime=" in el and not "endtime=" in el]
+                parsed.append('starttime=' + datetime.strftime(date,"%Y-%m-%d"))
+                variodata = "&".join(parsed)
             if len(variodbtest) > 1:
                 variostr = dbase.readDB(variodbtest[0],variodbtest[1],starttime=date,endtime=date+timedelta(days=1))
             else:
                 variostr = read(variodata,starttime=date,endtime=date+timedelta(days=1))
             print("Length of Variodata:", variostr.length()[0])
-            if not variostr.header.get('SensorID') == '':
-                 varioid = variostr.header.get('SensorID')
+            if not variostr.header.get('SensorID', '') == '':
+                varioid = variostr.header.get('SensorID')
+            elif not variostr.header.get('StationID', '') == '':
+                varioid = variostr.header.get('StationID')
             if db and not skipvariodb:
                 try:
                     vaflaglist = dbase.db2flaglist(db,variostr.header['SensorID'])
@@ -1774,7 +1795,7 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
                         print ("-- beta provided manually")
                 except:
                     print("Applying rotation parameters failed")
-              
+
             try:
                 variostr = variostr.remove_flagged()
                 print("Flagged records of variodata have been removed")
@@ -1783,6 +1804,7 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
         except:
             print("absoluteAnalysis: reading variometer data failed")
             variostr = DataStream()
+
         if (len(variostr) > 3 and not np.isnan(variostr.mean('time'))) or len(variostr.ndarray[0]) > 0: # can contain ([], 'File not specified')
             if offset:
                 variostr = variostr.offset(offset)
@@ -1790,12 +1812,12 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
                 valalpha = 0.0
             else:
                 valalpha = float(alpha)
-                print ("Rotating vector with manually provided alpha", valalpha) 
+                print ("Rotating vector with manually provided alpha", valalpha)
             if not beta:
                 valbeta = 0.0
             else:
                 valbeta = float(beta)
-                print ("Rotating vector with manually provided beta", valbeta) 
+                print ("Rotating vector with manually provided beta", valbeta)
             variostr =variostr.rotation(alpha=valalpha, beta=valbeta)
             #alpha = None
             #beta = None
@@ -1812,13 +1834,23 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
         #    deltaF = 0.0
         print("-----------------")
         try:
-            scalardbtest = scalardata.split(',')
+            if not "elements=" in scalardata:
+                scalardbtest = scalardata.split(',')
+            else:
+                scalardbtest = [scalardata]
+            if "starttime=" in variodata:
+                parsed = scalardata.split('&')
+                parsed = [el for el in parsed if not "starttime=" in el and not "endtime=" in el]
+                parsed.append('starttime=' + datetime.strftime(date,"%Y-%m-%d"))
+                scalardata = "&".join(parsed)
             if len(scalardbtest) > 1:
                 scalarstr = dbase.readDB(scalardbtest[0],scalardbtest[1],starttime=date,endtime=date+timedelta(days=1))
             else:
                 scalarstr = read(scalardata,starttime=date,endtime=date+timedelta(days=1))
-            if not scalarstr.header.get('SensorID') == '':
-                 scalarid = scalarstr.header.get('SensorID')
+            if not scalarstr.header.get('SensorID', '') == '':
+                scalarid = scalarstr.header.get('SensorID')
+            elif not scalarstr.header.get('StationID', '') == '':
+                scalarid = scalarstr.header.get('StationID')
             # Check for the presence of f or df
             fcol = KEYLIST.index('f')
             dfcol = KEYLIST.index('df')
@@ -1884,7 +1916,6 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
                 difiles = [di for di in filelist]
 
             #print ("Here", difiles, filelist)
-
             if len(difiles) > 0:
                 for elem in difiles:
                     # Get stationid and pier from name (if not provided)
@@ -1905,11 +1936,13 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
                     #    print("Please note that any offsets defined in DataDeltaValues")
                     #    print("of the database have been applied already.")
                     #    print("Data from %s, pier %s: manually defined are deltaF=%.2f" % (stationid, pier, deltaF))
-                    absst = absRead(elem,azimuth=azimuth,pier=pier,output='DIListStruct')
+                    if dataformat == 'JSONABS':
+                        absst = absRead(elem,dataformat=dataformat,azimuth=azimuth,pier=pier,output='DIListStruct')
+                    else:
+                        absst = absRead(elem,azimuth=azimuth,pier=pier,output='DIListStruct')
                     #print ("LENGTH:",len(absst))
                     #print ("ABSST:",absst)
-
-                    try: 
+                    try:
                         if not len(absst) > 1: # Manual
                             stream = absst[0].getAbsDIStruct()
                             abslist.append(absst)
@@ -1959,7 +1992,7 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
                 stream = absst.getAbsDIStruct()
             # if usestep not given and AutoDIF measurement found
             #print ("Identified pier in file:", stream[0])
-    
+
             if stream[0].person == 'AutoDIF' and not usestep:
                 usestep = 2
 
@@ -1986,7 +2019,7 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
                     try:
                         val= dbselect(db,'DeltaDictionary','PIERS','PierID like "{}"'.format(pier))[0]
                         deltainputs = val.split(',')
-                        lastval = deltainputs[-1] 
+                        lastval = deltainputs[-1]
                         deltaD = float(lastval.split('_')[2])
                     except:
                         deltaD = 0.0
@@ -2014,7 +2047,7 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
                     elif not alpha == None:
                         alphavaluetobeadded = alpha
                     if not result.str4 == '':
-                        result.str4 = result.str4 + ","    
+                        result.str4 = result.str4 + ","
                     result.str4 += "alpha_" + str(alphavaluetobeadded)
                 #print("absolutes", result.str4, valbeta, beta)
                 if valbeta != 0 or beta:
@@ -2025,7 +2058,7 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
                     elif not beta == 0:
                         betavaluetobeadded = beta
                     if not result.str4 == '':
-                        result.str4 = result.str4 + ","    
+                        result.str4 = result.str4 + ","
                     result.str4 += "beta_" + str(betavaluetobeadded)
                 #print("absolutes", result.str4)
             except:
@@ -2101,7 +2134,8 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
 
     #print "outfile"
     #print resultstream.ndarray
-
+    if varioid == scalarid:
+        stationid = varioid
     # 3.1 Header information
     # --------------------
     resultstream.header['StationID'] = stationid
@@ -2113,7 +2147,7 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
     resultstream.header['unit-col-x'] = 'deg'
     resultstream.header['col-y'] = 'd'
     resultstream.header['unit-col-y'] = 'deg'
-    resultstream.header['col-z'] = 'f'
+    resultstream.header['col-z'] = 'z'
     resultstream.header['unit-col-z'] = 'nT'
     resultstream.header['col-f'] = 'f'
     resultstream.header['unit-col-f'] = 'nT'
@@ -2313,5 +2347,3 @@ if __name__ == '__main__':
     print("Starting a test of the Absolutes program:")
     #msg = PyMagLog()
     ### TODO: To be implemented
-
-

--- a/magpy/absolutes.py
+++ b/magpy/absolutes.py
@@ -1496,7 +1496,7 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
         - expI:         (float) expected Inclination - failure produced when I differs by more than expT deg
         - expT:         (float) expected value threshold - default 1 deg
         - movetoarchive:(string) define a local directory to store archived data (only works when reading files)
-        - usgsstream:   ((DataStream object) provides vario and scalar data as an alternative to reading files
+        - datastream:   ((DataStream object) provides vario and scalar data as an alternative to reading files
     RETURNS:
         --
     EXAMPLE:
@@ -1549,7 +1549,7 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
     expD = kwargs.get('expD')
     meantime = kwargs.get('meantime')
     movetoarchive = kwargs.get('movetoarchive')
-    usgsdata = kwargs.get('usgsdata')
+    datastream = kwargs.get('datastream')
 
     if not outputformat:
         outputformat='idf'
@@ -1663,6 +1663,8 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
             if "starttime=" in elem:
                 pos = elem.find("starttime=")+10
                 epos = elem.find('&',pos)
+                if epos == -1:
+                    epos = len(elem)
                 datelist += [elem[pos:epos]]
             if len(datelist) == 0:
                 try:
@@ -1683,19 +1685,48 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
     if not len(datetimelist) > 0:
         print("absoluteAnalysis: No matching dates found - aborting")
         return
-
-    if usgsdata:
+    if datastream:
+        url = variodata
+        if 'sampling_period' in url:
+            pos = url.find("starttime=")+10
+            epos = url.find('&',pos)
+            if epos == -1:
+                epos = len(url)
+            deltat = int(url[pos:epos])
+        else:
+            deltat = 60
         starttime = sorted(datetimelist)[0]
         endtime = sorted(datetimelist)[-1] + timedelta(days=1)
-        parsed = variodata.split('&')
-        parsed = [el for el in parsed if not "starttime=" in el and not "endtime=" in el]
-        parsed.append('starttime=' + datetime.strftime(starttime,"%Y-%m-%d"))
-        parsed.append('endtime=' + datetime.strftime(endtime,"%Y-%m-%d"))
-        variodata = "&".join(parsed)
-        try:
-            usgsstream = read(variodata)
-        except:
-            print('Unable to load USGS scalar and vario data from: ' + variodata)
+        streamstart=datastream.ndarray[KEYLIST.index('time')][0]
+        streamend=datastream.ndarray[KEYLIST.index('time')][-1]
+        streamstart = num2date(streamstart).replace(tzinfo=None)
+        streamend = num2date(streamend).replace(tzinfo=None)
+        if starttime < streamstart and streamstart-starttime > timedelta(seconds=deltat):
+            parsed = url.split('&')
+            parsed = [el for el in parsed if not "starttime=" in el and not "endtime=" in el]
+            parsed.append('starttime=' + datetime.strftime(starttime,"%Y-%m-%d"))
+            parsed.append('endtime=' + datetime.strftime(streamstart,"%Y-%m-%d"))
+            url = "&".join(parsed)
+            try:
+                tempstream = read(url)
+                datastream = joinStreams(tempstream,datastream)
+            except:
+                print('Unable to load USGS scalar and vario data from: ' + url)
+        if endtime > streamend and endtime-streamend > timedelta(seconds=deltat):
+            parsed = url.split('&')
+            parsed = [el for el in parsed if not "starttime=" in el and not "endtime=" in el]
+            parsed.append('starttime=' + datetime.strftime(streamend,"%Y-%m-%d"))
+            parsed.append('endtime=' + datetime.strftime(endtime,"%Y-%m-%d"))
+            url = "&".join(parsed)
+            try:
+                tempstream = read(url)
+                datastream = joinStreams(datastream,tempstream)
+            except:
+                print('Unable to load USGS scalar and vario data from: ' + url)
+        streamstart=datastream.ndarray[KEYLIST.index('time')][0]
+        streamend=datastream.ndarray[KEYLIST.index('time')][-1]
+        streamstart = num2date(streamstart).replace(tzinfo=None)
+        streamend = num2date(streamend).replace(tzinfo=None)
         # Please Note for pier information always the existing pier in the file is used
 
     # 2.2 Cycle through datetimelist
@@ -1720,16 +1751,16 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
                 variodbtest = variodata.split(',')
             else:
                 variodbtest = [variodata]
-            if usgsstream:
-                starttime = usgsstream.ndarray[KEYLIST.index('time')][0]
-                endtime = usgsstream.ndarray[KEYLIST.index('time')][-1]
+            if datastream:
+                starttime = datastream.ndarray[KEYLIST.index('time')][0]
+                endtime = datastream.ndarray[KEYLIST.index('time')][-1]
                 starttime = num2date(starttime).replace(tzinfo=None)
                 endtime = num2date(endtime).replace(tzinfo=None)
                 if date+timedelta(days=1) > endtime:
-                    newarray = usgsstream._select_timerange(starttime=date, endtime=endtime)
+                    newarray = datastream._select_timerange(starttime=date, endtime=endtime)
                 else:
-                    newarray = usgsstream._select_timerange(starttime=date, endtime=date+timedelta(days=1))
-                variostr = DataStream([LineStruct()],usgsstream.header,newarray)
+                    newarray = datastream._select_timerange(starttime=date, endtime=date+timedelta(days=1))
+                variostr = DataStream([LineStruct()],datastream.header,newarray)
             else:
                 if len(variodbtest) > 1:
                     variostr = dbase.readDB(variodbtest[0],variodbtest[1],starttime=date,endtime=date+timedelta(days=1))
@@ -1849,16 +1880,16 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
                 scalardbtest = scalardata.split(',')
             else:
                 scalardbtest = [scalardata]
-            if usgsstream:
-                starttime = usgsstream.ndarray[KEYLIST.index('time')][0]
-                endtime = usgsstream.ndarray[KEYLIST.index('time')][-1]
+            if datastream:
+                starttime = datastream.ndarray[KEYLIST.index('time')][0]
+                endtime = datastream.ndarray[KEYLIST.index('time')][-1]
                 starttime = num2date(starttime).replace(tzinfo=None)
                 endtime = num2date(endtime).replace(tzinfo=None)
                 if date+timedelta(days=1) > endtime:
-                    newarray = usgsstream._select_timerange(starttime=date, endtime=endtime)
+                    newarray = datastream._select_timerange(starttime=date, endtime=endtime)
                 else:
-                    newarray = usgsstream._select_timerange(starttime=date, endtime=date+timedelta(days=1))
-                scalarstr = DataStream([LineStruct()],usgsstream.header,newarray)
+                    newarray = datastream._select_timerange(starttime=date, endtime=date+timedelta(days=1))
+                scalarstr = DataStream([LineStruct()],datastream.header,newarray)
             else:
                 if len(scalardbtest) > 1:
                     scalarstr = dbase.readDB(scalardbtest[0],scalardbtest[1],starttime=date,endtime=date+timedelta(days=1))

--- a/magpy/absolutes.py
+++ b/magpy/absolutes.py
@@ -154,7 +154,6 @@ class DILineStruct(object):
 
         # The order needs to be changed according to the file list
 
-
         for i, elem in enumerate(self.time):
             if 4 <= i < 12 or 16 <= i < 25:
                 row = AbsoluteDIStruct()
@@ -326,14 +325,12 @@ class AbsoluteData(object):
             return False
         # 2. Get time column
         timea = np.asarray(datastream._get_column('time'))
-
         # 3. Get time column of DI data
         timeb = np.asarray([el.time for el in self])
         # 4. search
         #print(len(timea), len(timeb), samprate)
         #print(timea, timeb)
         indtia = [idx for idx, el in enumerate(timeb) if np.min(np.abs(timea-float(el)))/(samprate/24./3600.)*2 <= 1.]
-
         if not len(indtia) == len(timeb):
             return False
 
@@ -1577,8 +1574,6 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
 
     varioid = 'Unknown'
     scalarid = 'Unknown'
-
-
     # ####################################
     # 2. Get absolute data
     # ####################################
@@ -1619,7 +1614,6 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
         except:
             print("absoluteAnalysis:  getting DI data from files")
             pass
-
 
     if readfile:
         # Get list of files
@@ -1804,7 +1798,6 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
         except:
             print("absoluteAnalysis: reading variometer data failed")
             variostr = DataStream()
-
         if (len(variostr) > 3 and not np.isnan(variostr.mean('time'))) or len(variostr.ndarray[0]) > 0: # can contain ([], 'File not specified')
             if offset:
                 variostr = variostr.offset(offset)

--- a/magpy/absolutes.py
+++ b/magpy/absolutes.py
@@ -1688,7 +1688,7 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
     if datastream:
         url = variodata
         if 'sampling_period' in url:
-            pos = url.find("starttime=")+10
+            pos = url.find("sampling_period=")+len("sampling_period=")
             epos = url.find('&',pos)
             if epos == -1:
                 epos = len(url)

--- a/magpy/absolutes.py
+++ b/magpy/absolutes.py
@@ -1496,6 +1496,7 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
         - expI:         (float) expected Inclination - failure produced when I differs by more than expT deg
         - expT:         (float) expected value threshold - default 1 deg
         - movetoarchive:(string) define a local directory to store archived data (only works when reading files)
+        - usgsstream:   ((DataStream object) provides vario and scalar data as an alternative to reading files
     RETURNS:
         --
     EXAMPLE:
@@ -1548,6 +1549,7 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
     expD = kwargs.get('expD')
     meantime = kwargs.get('meantime')
     movetoarchive = kwargs.get('movetoarchive')
+    usgsdata = kwargs.get('usgsdata')
 
     if not outputformat:
         outputformat='idf'
@@ -1671,7 +1673,6 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
                     failinglist.append(elem)
 
         datelist = list(set(datelist))
-
     datetimelist = [datetime.strptime(elem,'%Y-%m-%d') for elem in datelist]
 
     empty = DataStream()
@@ -1683,7 +1684,18 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
         print("absoluteAnalysis: No matching dates found - aborting")
         return
 
-
+    if usgsdata:
+        starttime = sorted(datetimelist)[0]
+        endtime = sorted(datetimelist)[-1] + timedelta(days=1)
+        parsed = variodata.split('&')
+        parsed = [el for el in parsed if not "starttime=" in el and not "endtime=" in el]
+        parsed.append('starttime=' + datetime.strftime(starttime,"%Y-%m-%d"))
+        parsed.append('endtime=' + datetime.strftime(endtime,"%Y-%m-%d"))
+        variodata = "&".join(parsed)
+        try:
+            usgsstream = read(variodata)
+        except:
+            print('Unable to load USGS scalar and vario data from: ' + variodata)
         # Please Note for pier information always the existing pier in the file is used
 
     # 2.2 Cycle through datetimelist
@@ -1708,15 +1720,21 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
                 variodbtest = variodata.split(',')
             else:
                 variodbtest = [variodata]
-            if "starttime=" in variodata:
-                parsed = variodata.split('&')
-                parsed = [el for el in parsed if not "starttime=" in el and not "endtime=" in el]
-                parsed.append('starttime=' + datetime.strftime(date,"%Y-%m-%d"))
-                variodata = "&".join(parsed)
-            if len(variodbtest) > 1:
-                variostr = dbase.readDB(variodbtest[0],variodbtest[1],starttime=date,endtime=date+timedelta(days=1))
+            if usgsstream:
+                starttime = usgsstream.ndarray[KEYLIST.index('time')][0]
+                endtime = usgsstream.ndarray[KEYLIST.index('time')][-1]
+                starttime = num2date(starttime).replace(tzinfo=None)
+                endtime = num2date(endtime).replace(tzinfo=None)
+                if date+timedelta(days=1) > endtime:
+                    newarray = usgsstream._select_timerange(starttime=date, endtime=endtime)
+                else:
+                    newarray = usgsstream._select_timerange(starttime=date, endtime=date+timedelta(days=1))
+                variostr = DataStream([LineStruct()],usgsstream.header,newarray)
             else:
-                variostr = read(variodata,starttime=date,endtime=date+timedelta(days=1))
+                if len(variodbtest) > 1:
+                    variostr = dbase.readDB(variodbtest[0],variodbtest[1],starttime=date,endtime=date+timedelta(days=1))
+                else:
+                    variostr = read(variodata,starttime=date,endtime=date+timedelta(days=1))
             print("Length of Variodata:", variostr.length()[0])
             if not variostr.header.get('SensorID', '') == '':
                 varioid = variostr.header.get('SensorID')
@@ -1831,15 +1849,21 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
                 scalardbtest = scalardata.split(',')
             else:
                 scalardbtest = [scalardata]
-            if "starttime=" in variodata:
-                parsed = scalardata.split('&')
-                parsed = [el for el in parsed if not "starttime=" in el and not "endtime=" in el]
-                parsed.append('starttime=' + datetime.strftime(date,"%Y-%m-%d"))
-                scalardata = "&".join(parsed)
-            if len(scalardbtest) > 1:
-                scalarstr = dbase.readDB(scalardbtest[0],scalardbtest[1],starttime=date,endtime=date+timedelta(days=1))
+            if usgsstream:
+                starttime = usgsstream.ndarray[KEYLIST.index('time')][0]
+                endtime = usgsstream.ndarray[KEYLIST.index('time')][-1]
+                starttime = num2date(starttime).replace(tzinfo=None)
+                endtime = num2date(endtime).replace(tzinfo=None)
+                if date+timedelta(days=1) > endtime:
+                    newarray = usgsstream._select_timerange(starttime=date, endtime=endtime)
+                else:
+                    newarray = usgsstream._select_timerange(starttime=date, endtime=date+timedelta(days=1))
+                scalarstr = DataStream([LineStruct()],usgsstream.header,newarray)
             else:
-                scalarstr = read(scalardata,starttime=date,endtime=date+timedelta(days=1))
+                if len(scalardbtest) > 1:
+                    scalarstr = dbase.readDB(scalardbtest[0],scalardbtest[1],starttime=date,endtime=date+timedelta(days=1))
+                else:
+                    scalarstr = read(scalardata,starttime=date,endtime=date+timedelta(days=1))
             if not scalarstr.header.get('SensorID', '') == '':
                 scalarid = scalarstr.header.get('SensorID')
             elif not scalarstr.header.get('StationID', '') == '':

--- a/magpy/absolutes.py
+++ b/magpy/absolutes.py
@@ -1930,7 +1930,10 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
                     #    print("of the database have been applied already.")
                     #    print("Data from %s, pier %s: manually defined are deltaF=%.2f" % (stationid, pier, deltaF))
                     if dataformat == 'JSONABS':
-                        absst = absRead(elem,dataformat=dataformat,azimuth=azimuth,pier=pier,output='DIListStruct')
+                        try:
+                            absst = absRead(elem,dataformat=dataformat,azimuth=azimuth,pier=pier,output='DIListStruct')
+                        except:
+                            print("Unable to read DI data for " + date.strftime("%Y-%m-%d"))
                     else:
                         absst = absRead(elem,azimuth=azimuth,pier=pier,output='DIListStruct')
                     #print ("LENGTH:",len(absst))

--- a/magpy/absolutes.py
+++ b/magpy/absolutes.py
@@ -1660,7 +1660,7 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
             head, tail = os.path.split(elem)
             if "starttime=" in elem:
                 pos = elem.find("starttime=")+10
-                epos = pos + 10
+                epos = elem.find('&',pos)
                 datelist += [elem[pos:epos]]
             if len(datelist) == 0:
                 try:

--- a/magpy/gui/absolutespage.py
+++ b/magpy/gui/absolutespage.py
@@ -33,6 +33,7 @@ class AbsolutePage(wx.Panel):
     def createControls(self):
         self.diLabel = wx.StaticText(self, label="DI files:")
         self.loadDIButton = wx.Button(self,-1,"Load DI data",size=(160,30))
+        self.loadUSGSButton = wx.Button(self,-1,"Load USGS data",size=(160,30))
         self.diTextCtrl = wx.TextCtrl(self, value="None",size=(160,40),
                           style = wx.TE_MULTILINE|wx.TE_READONLY|wx.HSCROLL|wx.VSCROLL)
         self.defineVarioButton = wx.Button(self,-1,"Variometer path",size=(160,30))
@@ -71,7 +72,7 @@ class AbsolutePage(wx.Panel):
         # and the logger text control (on the right):
         boxSizer = wx.BoxSizer(orient=wx.HORIZONTAL)
         # A GridSizer will contain the other controls:
-        gridSizer = wx.FlexGridSizer(rows=10, cols=2, vgap=10, hgap=10)
+        gridSizer = wx.FlexGridSizer(rows=11, cols=2, vgap=10, hgap=10)
 
         # Prepare some reusable arguments for calling sizer.Add():
         expandOption = dict(flag=wx.EXPAND)
@@ -86,6 +87,8 @@ class AbsolutePage(wx.Panel):
                  (self.varioTextCtrl, expandOption),
                  (self.defineScalarButton, dict(flag=wx.ALIGN_CENTER)),
                  (self.scalarTextCtrl, expandOption),
+                 (self.loadUSGSButton,dict(flag=wx.ALIGN_CENTER)),
+                  emptySpace,
                   emptySpace,
                   emptySpace,
                  (self.diLabel, noOptions),

--- a/magpy/gui/dialogclasses.py
+++ b/magpy/gui/dialogclasses.py
@@ -2475,28 +2475,18 @@ class LoadUSGSDialog(wx.Dialog):
         startvalue = datetime.fromtimestamp(startvalue.GetTicks()).replace(tzinfo=None)
         endvalue = self.endDatePicker.GetValue()
         endvalue = datetime.fromtimestamp(endvalue.GetTicks()).replace(tzinfo=None)
-        # Dates from stream
-        streamstart = self.stream.ndarray[KEYLIST.index('time')][0]
-        streamend = self.stream.ndarray[KEYLIST.index('time')][-1]
-        streamstart = num2date(streamstart).replace(tzinfo=None)
-        streamend = num2date(streamend).replace(tzinfo=None)
-        if streamstart == startvalue and streamend == endvalue:
-            starttime = streamstart
-            endtime = streamend
-        else:
-            starttime = startvalue
-            endtime = endvalue
+        starttime = startvalue
+        endtime = endvalue + timedelta(days=1)
         base = 'https://geomag.usgs.gov/baselines/observation.json.php?'
         time = starttime
-        while time < endtime:
+        while time <= endtime:
             start = time.strftime('%Y-%m-%d')
             time = time + timedelta(days=1)
-            end = time.strftime('%Y-%m-%d')
+            end = endtime + timedelta(days=5)
+            end = end.strftime('%Y-%m-%d')
             url = base + 'observatory=' + obsid + '&starttime=' + \
-                start + '&includemeasurements=true'
+                start + '&endtime=' + end + '&includemeasurements=true'
             self.urls += [url]
-
-
 
 
 class DefineVarioDialog(wx.Dialog):

--- a/magpy/gui/dialogclasses.py
+++ b/magpy/gui/dialogclasses.py
@@ -2350,6 +2350,66 @@ class LoadDIDialog(wx.Dialog):
         dlg.Destroy()
         self.Close(True)
 
+class LoadUSGSDialog(wx.Dialog):
+    """
+    Dialog for Stream panel
+    Dialog for loading USGS absolutes data.
+    """
+
+    def __init__(self, parent, title):
+        super(LoadUSGSDialog, self).__init__(parent=parent,
+            title=title, size=(600, 600))
+        self.createControls()
+        self.doLayout()
+
+    # Widgets
+    def createControls(self):
+        extension_options = ['0 days', '1 day', '2 days', '3 days', '4 days',
+                '5 days', '6 days', '1 week', '2 weeks',  '3 weeks',
+                '4 weeks', '8 weeks']
+        info = ('Extending the beginning and end of the time range will ensure'
+                ' that the scalar and variometer data is covered by the available'
+                ' baseline data. (4 days recommended)')
+        self.extensionText = wx.StaticText(self,-1,"Extension amount:",size=(500,20))
+        self.infoText = wx.StaticText(self,-1,info,size=(500,50))
+        self.extensionComboBox = wx.ComboBox(self, choices=extension_options,
+            style=wx.CB_DROPDOWN, value=extension_options[0],size=(500,-1))
+        self.closeButton = wx.Button(self, wx.ID_CANCEL, label='Cancel',size=(500,20))
+        self.okButton = wx.Button(self, wx.ID_OK, label='Ok',size=(500,20))
+
+    def doLayout(self):
+        # A horizontal BoxSizer will contain the GridSizer (on the left)
+        # and the logger text control (on the right):
+        boxSizer = wx.BoxSizer(orient=wx.HORIZONTAL)
+
+        # Prepare some reusable arguments for calling sizer.Add():
+        expandOption = dict(flag=wx.EXPAND)
+        noOptions = dict()
+        emptySpace = ((0, 0), noOptions)
+
+        # Add the controls to the sizers:
+        controls = [(self.infoText, noOptions),
+        (self.extensionText, noOptions),
+        (self.extensionComboBox,  dict(flag=wx.ALIGN_CENTER)),
+        (self.okButton, dict(flag=wx.ALIGN_CENTER)),
+        (self.closeButton, dict(flag=wx.ALIGN_CENTER)),
+        ]
+
+        # A GridSizer will contain the other controls:
+        cols = 1
+        rows = int(np.ceil(len(controls)/float(cols)))
+        gridSizer = wx.FlexGridSizer(rows=rows, cols=cols, vgap=10, hgap=10)
+
+        for control, options in controls:
+            gridSizer.Add(control, **options)
+
+        for control, options in \
+                [(gridSizer, dict(border=5, flag=wx.ALL))]:
+            boxSizer.Add(control, **options)
+
+        self.SetSizerAndFit(boxSizer)
+
+
 
 class DefineVarioDialog(wx.Dialog):
     """

--- a/magpy/gui/dialogclasses.py
+++ b/magpy/gui/dialogclasses.py
@@ -2364,7 +2364,6 @@ class LoadUSGSDialog(wx.Dialog):
         self.createControls()
         self.doLayout()
         self.bindControls()
-        self.createUrls()
 
     # Widgets
     def createControls(self):
@@ -2385,6 +2384,8 @@ class LoadUSGSDialog(wx.Dialog):
         endtime = num2date(endtime)
         start = wx.DateTimeFromTimeT(time.mktime(starttime.timetuple()))
         end = wx.DateTimeFromTimeT(time.mktime(endtime.timetuple()))
+        self.starttime = starttime
+        self.endtime = endtime
         self.dateInfoText = wx.StaticText(self,-1,dateinfo,size=(500,65))
         self.startText = wx.StaticText(self,-1,"Start Date:",size=(500,15))
         self.startDatePicker = wx.DatePickerCtrl(self, dt=start,size=(500,25))
@@ -2446,7 +2447,10 @@ class LoadUSGSDialog(wx.Dialog):
         self.endDatePicker.Bind(wx.EVT_DATE_CHANGED, self.onChangeDate)
 
     def onChangeDate(self, e):
-        self.createUrls()
+        starttime = self.startDatePicker.GetValue()
+        self.starttime = datetime.fromtimestamp(starttime.GetTicks())
+        endtime = self.endDatePicker.GetValue()
+        self.endtime = datetime.fromtimestamp(endtime.GetTicks())
 
     def onExtend(self, e):
         startvalue = self.startDatePicker.GetValue()
@@ -2466,31 +2470,8 @@ class LoadUSGSDialog(wx.Dialog):
         end = wx.DateTimeFromTimeT(time.mktime(endtime.timetuple()))
         self.startDatePicker.SetValue(start)
         self.endDatePicker.SetValue(end)
-        self.createUrls()
-
-    def createUrls(self):
-        self.urls = []
-        obsid = self.stream.header.get('StationID', '')
-        extension = self.extensionComboBox.GetString(self.extensionComboBox.GetSelection())
-        dt = extension[0]
-        # Dates from pickers
-        startvalue = self.startDatePicker.GetValue()
-        startvalue = datetime.fromtimestamp(startvalue.GetTicks()).replace(tzinfo=None)
-        endvalue = self.endDatePicker.GetValue()
-        endvalue = datetime.fromtimestamp(endvalue.GetTicks()).replace(tzinfo=None)
-        starttime = startvalue
-        endtime = endvalue + timedelta(days=1)
-        base = 'https://geomag.usgs.gov/baselines/observation.json.php?'
-        time = starttime
-        while time <= endtime:
-            start = time.strftime('%Y-%m-%d')
-            time = time + timedelta(days=1)
-            end = endtime + timedelta(days=5)
-            end = end.strftime('%Y-%m-%d')
-            url = base + 'observatory=' + obsid + '&starttime=' + \
-                start + '&endtime=' + end + '&includemeasurements=true'
-            self.urls += [url]
-
+        self.starttime = starttime
+        self.endtime = endtime
 
 class DefineVarioDialog(wx.Dialog):
     """

--- a/magpy/gui/dialogclasses.py
+++ b/magpy/gui/dialogclasses.py
@@ -2356,26 +2356,46 @@ class LoadUSGSDialog(wx.Dialog):
     Dialog for loading USGS absolutes data.
     """
 
-    def __init__(self, parent, title):
+    def __init__(self, parent, title, stream):
         super(LoadUSGSDialog, self).__init__(parent=parent,
             title=title, size=(600, 600))
+        self.stream = stream
+        self.urls = []
         self.createControls()
         self.doLayout()
+        self.bindControls()
+        self.createUrls()
 
     # Widgets
     def createControls(self):
+        dateinfo = ('Specify a date range of absolutes data to be obtain from the'
+                ' USGS absolutes web service. The start and end dates should'
+                ' encompass the plotted data. Note: the default start and end'
+                ' dates correspond to thhe beginning and end of the plotted'
+                ' data.')
         extension_options = ['0 days', '1 day', '2 days', '3 days', '4 days',
                 '5 days', '6 days', '1 week', '2 weeks',  '3 weeks',
                 '4 weeks', '8 weeks']
-        info = ('Extending the beginning and end of the time range will ensure'
+        extinfo = ('Extending the beginning and end of the time range will ensure'
                 ' that the scalar and variometer data is covered by the available'
-                ' baseline data. (4 days recommended)')
-        self.extensionText = wx.StaticText(self,-1,"Extension amount:",size=(500,20))
-        self.infoText = wx.StaticText(self,-1,info,size=(500,50))
-        self.extensionComboBox = wx.ComboBox(self, choices=extension_options,
-            style=wx.CB_DROPDOWN, value=extension_options[0],size=(500,-1))
-        self.closeButton = wx.Button(self, wx.ID_CANCEL, label='Cancel',size=(500,20))
-        self.okButton = wx.Button(self, wx.ID_OK, label='Ok',size=(500,20))
+                ' baseline data. (3 days recommended)')
+        starttime = self.stream.ndarray[KEYLIST.index('time')][0]
+        endtime = self.stream.ndarray[KEYLIST.index('time')][-1]
+        starttime = num2date(starttime)
+        endtime = num2date(endtime)
+        start = wx.DateTimeFromTimeT(time.mktime(starttime.timetuple()))
+        end = wx.DateTimeFromTimeT(time.mktime(endtime.timetuple()))
+        self.dateInfoText = wx.StaticText(self,-1,dateinfo,size=(500,65))
+        self.startText = wx.StaticText(self,-1,"Start Date:",size=(500,15))
+        self.startDatePicker = wx.DatePickerCtrl(self, dt=start,size=(500,25))
+        self.endText = wx.StaticText(self,-1,"End Date:",size=(500,15))
+        self.endDatePicker = wx.DatePickerCtrl(self, dt=end,size=(500,25))
+        self.extensionText = wx.StaticText(self,-1,"Extension amount:",size=(500,15))
+        self.extInfoText = wx.StaticText(self,-1,extinfo,size=(500,35))
+        self.extensionComboBox = wx.Choice(self, choices=extension_options,
+            style=wx.CB_READONLY,size=(500,-1))
+        self.closeButton = wx.Button(self, wx.ID_CANCEL, label='Cancel',size=(500,25))
+        self.okButton = wx.Button(self, wx.ID_OK, label='Ok',size=(500,25))
 
     def doLayout(self):
         # A horizontal BoxSizer will contain the GridSizer (on the left)
@@ -2388,12 +2408,20 @@ class LoadUSGSDialog(wx.Dialog):
         emptySpace = ((0, 0), noOptions)
 
         # Add the controls to the sizers:
-        controls = [(self.infoText, noOptions),
-        (self.extensionText, noOptions),
-        (self.extensionComboBox,  dict(flag=wx.ALIGN_CENTER)),
-        (self.okButton, dict(flag=wx.ALIGN_CENTER)),
-        (self.closeButton, dict(flag=wx.ALIGN_CENTER)),
-        ]
+        controls = [(self.dateInfoText, noOptions),
+                (self.startText, noOptions),
+                (self.startDatePicker, dict(flag=wx.ALIGN_CENTER)),
+                (self.endText, noOptions),
+                (self.endDatePicker, dict(flag=wx.ALIGN_CENTER)),
+                emptySpace,
+                emptySpace,
+                (self.extInfoText, noOptions),
+                (self.extensionText, noOptions),
+                (self.extensionComboBox,  dict(flag=wx.ALIGN_CENTER)),
+                emptySpace,
+                emptySpace,
+                (self.okButton, dict(flag=wx.ALIGN_CENTER)),
+                (self.closeButton, dict(flag=wx.ALIGN_CENTER))]
 
         # A GridSizer will contain the other controls:
         cols = 1
@@ -2408,6 +2436,66 @@ class LoadUSGSDialog(wx.Dialog):
             boxSizer.Add(control, **options)
 
         self.SetSizerAndFit(boxSizer)
+
+    def bindControls(self):
+        self.extensionComboBox.Bind(wx.EVT_CHOICE, self.onExtend)
+        self.startDatePicker.Bind(wx.EVT_DATE_CHANGED, self.onChangeDate)
+        self.endDatePicker.Bind(wx.EVT_DATE_CHANGED, self.onChangeDate)
+
+    def onChangeDate(self, e):
+        self.createUrls()
+
+    def onExtend(self, e):
+        startvalue = self.startDatePicker.GetValue()
+        starttime = datetime.fromtimestamp(startvalue.GetTicks())
+        endvalue = self.endDatePicker.GetValue()
+        endtime = datetime.fromtimestamp(endvalue.GetTicks())
+        extension = self.extensionComboBox.GetString(self.extensionComboBox.GetSelection())
+        dt = extension[0]
+        dttype = extension[2]
+        if dttype == 'd':
+            dt = int(dt)
+        if dttype == 'w':
+            dt = int(dt) * 7
+        starttime = starttime - timedelta(days = dt)
+        endtime = endtime + timedelta(days = dt)
+        start = wx.DateTimeFromTimeT(time.mktime(starttime.timetuple()))
+        end = wx.DateTimeFromTimeT(time.mktime(endtime.timetuple()))
+        self.startDatePicker.SetValue(start)
+        self.endDatePicker.SetValue(end)
+        self.createUrls()
+
+    def createUrls(self):
+        self.urls = []
+        obsid = self.stream.header.get('StationID', '')
+        extension = self.extensionComboBox.GetString(self.extensionComboBox.GetSelection())
+        dt = extension[0]
+        # Dates from pickers
+        startvalue = self.startDatePicker.GetValue()
+        startvalue = datetime.fromtimestamp(startvalue.GetTicks()).replace(tzinfo=None)
+        endvalue = self.endDatePicker.GetValue()
+        endvalue = datetime.fromtimestamp(endvalue.GetTicks()).replace(tzinfo=None)
+        # Dates from stream
+        streamstart = self.stream.ndarray[KEYLIST.index('time')][0]
+        streamend = self.stream.ndarray[KEYLIST.index('time')][-1]
+        streamstart = num2date(streamstart).replace(tzinfo=None)
+        streamend = num2date(streamend).replace(tzinfo=None)
+        if streamstart == startvalue and streamend == endvalue:
+            starttime = streamstart
+            endtime = streamend
+        else:
+            starttime = startvalue
+            endtime = endvalue
+        base = 'https://geomag.usgs.gov/baselines/observation.json.php?'
+        time = starttime
+        while time < endtime:
+            start = time.strftime('%Y-%m-%d')
+            time = time + timedelta(days=1)
+            end = time.strftime('%Y-%m-%d')
+            url = base + 'observatory=' + obsid + '&starttime=' + \
+                start + '&includemeasurements=true'
+            self.urls += [url]
+
 
 
 

--- a/magpy/gui/dialogclasses.py
+++ b/magpy/gui/dialogclasses.py
@@ -2394,8 +2394,10 @@ class LoadUSGSDialog(wx.Dialog):
         self.extInfoText = wx.StaticText(self,-1,extinfo,size=(500,35))
         self.extensionComboBox = wx.Choice(self, choices=extension_options,
             style=wx.CB_READONLY,size=(500,-1))
+        self.analyzeCheckBox = wx.CheckBox(self, label='Run Analysis Automatically',size=(500,25))
         self.closeButton = wx.Button(self, wx.ID_CANCEL, label='Cancel',size=(500,25))
         self.okButton = wx.Button(self, wx.ID_OK, label='Ok',size=(500,25))
+        self.analyzeCheckBox.SetValue(True)
 
     def doLayout(self):
         # A horizontal BoxSizer will contain the GridSizer (on the left)
@@ -2418,6 +2420,7 @@ class LoadUSGSDialog(wx.Dialog):
                 (self.extInfoText, noOptions),
                 (self.extensionText, noOptions),
                 (self.extensionComboBox,  dict(flag=wx.ALIGN_CENTER)),
+                (self.analyzeCheckBox, dict(flag=wx.ALIGN_CENTER)),
                 emptySpace,
                 emptySpace,
                 (self.okButton, dict(flag=wx.ALIGN_CENTER)),

--- a/magpy/gui/magpy_gui.py
+++ b/magpy/gui/magpy_gui.py
@@ -5129,42 +5129,48 @@ Suite 330, Boston, MA  02111-1307  USA"""
         enddate = self.plotstream.ndarray[KEYLIST.index('time')][-1]
         starttime = num2date(startdate)
         endtime = num2date(enddate)
-        #if endtime - starttime < timedelta(days=5):
-        #    endtime = endtime+timedelta(days=5)
         di_db = []
-        time = starttime - timedelta(days = 4)
-        base = 'https://geomag.usgs.gov/baselines/observation.json.php?'
-        observatory = self.plotstream.header.get('StationID')
-        while time < endtime + timedelta(days = 7):
-            called_date = time.strftime('%Y-%m-%d')
-            time = time + timedelta(days=1)
-            url = base + 'observatory=' + observatory + '&starttime=' + \
-                    called_date + '&includemeasurements=true'
-            di_db += [url]
-        self.menu_p.rep_page.logMsg("- loaded DI data")
-        self.menu_p.abs_page.diTextCtrl.SetValue('  '.join(di_db))
-        self.dipathlist = di_db
-        self.options['dipathlist'] = di_db
-        vario_scalar = self.menu_p.str_page.pathTextCtrl.GetValue()
-        self.menu_p.abs_page.varioTextCtrl.SetValue(vario_scalar)
-        self.options['divariopath'] = vario_scalar
-        self.menu_p.abs_page.scalarTextCtrl.SetValue(vario_scalar)
-        self.options['discalarpath'] = vario_scalar
-        self.menu_p.abs_page.AnalyzeButton.Enable()
-        # remove defaults
-        dlg = DISetParameterDialog(None, title='Set Parameter')
-        dlg.expDTextCtrl.SetValue('')
-        dlg.azimuthTextCtrl.SetValue('')
-        dlg.pierTextCtrl.SetValue('')
-        dlg.alphaTextCtrl.SetValue('')
-        dlg.deltaFTextCtrl.SetValue('')
-        self.options['diexpD'] = dlg.expDTextCtrl.GetValue()
-        self.options['diazimuth'] = dlg.azimuthTextCtrl.GetValue()
-        self.options['dipier'] = dlg.pierTextCtrl.GetValue()
-        self.options['dialpha'] = dlg.alphaTextCtrl.GetValue()
-        self.options['dideltaF'] = dlg.deltaFTextCtrl.GetValue()
-        self.options['diexpI']=''
-
+        dlg = LoadUSGSDialog(None, title='Get USGS data')
+        if dlg.ShowModal() == wx.ID_OK:
+            extension = dlg.extensionComboBox.GetValue()
+            dt = extension[0]
+            dttype = extension[2]
+            if dttype == 'd':
+                dt = int(dt)
+            if dttype == 'w':
+                dt = int(dt) * 7
+            time = starttime - timedelta(days = dt)
+            base = 'https://geomag.usgs.gov/baselines/observation.json.php?'
+            observatory = self.plotstream.header.get('StationID')
+            while time < endtime + timedelta(days = dt):
+                called_date = time.strftime('%Y-%m-%d')
+                time = time + timedelta(days=1)
+                url = base + 'observatory=' + observatory + '&starttime=' + \
+                        called_date + '&includemeasurements=true'
+                di_db += [url]
+            self.menu_p.rep_page.logMsg("- loaded DI data")
+            self.menu_p.abs_page.diTextCtrl.SetValue('  '.join(di_db))
+            self.dipathlist = di_db
+            self.options['dipathlist'] = di_db
+            vario_scalar = self.menu_p.str_page.pathTextCtrl.GetValue()
+            self.menu_p.abs_page.varioTextCtrl.SetValue(vario_scalar)
+            self.options['divariopath'] = vario_scalar
+            self.menu_p.abs_page.scalarTextCtrl.SetValue(vario_scalar)
+            self.options['discalarpath'] = vario_scalar
+            self.menu_p.abs_page.AnalyzeButton.Enable()
+            # remove defaults
+            dlg = DISetParameterDialog(None, title='Set Parameter')
+            dlg.expDTextCtrl.SetValue('')
+            dlg.azimuthTextCtrl.SetValue('')
+            dlg.pierTextCtrl.SetValue('')
+            dlg.alphaTextCtrl.SetValue('')
+            dlg.deltaFTextCtrl.SetValue('')
+            self.options['diexpD'] = dlg.expDTextCtrl.GetValue()
+            self.options['diazimuth'] = dlg.azimuthTextCtrl.GetValue()
+            self.options['dipier'] = dlg.pierTextCtrl.GetValue()
+            self.options['dialpha'] = dlg.alphaTextCtrl.GetValue()
+            self.options['dideltaF'] = dlg.deltaFTextCtrl.GetValue()
+            self.options['diexpI']=''
 
     def onDefineVario(self,event):
         """

--- a/magpy/gui/magpy_gui.py
+++ b/magpy/gui/magpy_gui.py
@@ -1283,6 +1283,7 @@ class MainFrame(wx.Frame):
         # Essential header info
         comps = stream.header.get('DataComponents','')[:3]
         sensorid = stream.header.get('SensorID','')
+        stationid = stream.header.get('StationID', '')
         dataid = self.plotstream.header.get('DataID','')
         formattype = self.plotstream.header.get('DataFormat','')
         absinfo = self.plotstream.header.get('DataAbsInfo',None)
@@ -1315,7 +1316,7 @@ class MainFrame(wx.Frame):
             basedict = {'startdate':mintime,'enddate':maxtime, 'filename':filename, 'streamidx':len(self.streamlist)-1}
             self.baselinedictlst.append(basedict)
 
-        def checkbaseline(baselinedictlst, sensorid, mintime, maxtime):
+        def checkbaseline(baselinedictlst, sensorid, mintime, maxtime, stationid=None):
             """
               DESCRIPTION:
                 check whether valid baseline info is existing
@@ -1384,6 +1385,10 @@ class MainFrame(wx.Frame):
         self.menu_p.ana_page.powerButton.Enable()         # always
         self.menu_p.ana_page.spectrumButton.Enable()      # always
 
+        # ----------------------------------------
+        # absolutes page
+        self.menu_p.abs_page.loadUSGSButton.Enable()      # always
+
         # Selective fields
         # ----------------------------------------
         #print ("COMPONENTS", comps)
@@ -1427,9 +1432,9 @@ class MainFrame(wx.Frame):
             self.menu_p.ana_page.activityButton.Enable()      # activate if vector appears to be present
             if 'f' in keys and not 'df' in keys:
                 self.menu_p.ana_page.deltafButton.Enable()    # activate if full vector present
-            if not formattype == 'MagPyDI':
+            if formattype == 'MagPyDI':
                 #print ("Checking baseline info")
-                self.baselineidxlst = checkbaseline(self.baselinedictlst, sensorid, mintime, maxtime)
+                self.baselineidxlst = checkbaseline(self.baselinedictlst, sensorid, mintime, maxtime, stationid)
                 if len(self.baselineidxlst) > 0:
                     self.menu_p.ana_page.baselineButton.Enable()  # activate if baselinedata is existing
 
@@ -2362,19 +2367,22 @@ Suite 330, Boston, MA  02111-1307  USA"""
             time = datetime.strftime(num2date(time),"%Y-%m-%d %H:%M:%S %Z")
         except:
             time = num2date(time)
-        for elem in self.shownkeylist:
-            ul = np.nanmax(self.plotstream.ndarray[KEYLIST.index(elem)])
-            ll = np.nanmin(self.plotstream.ndarray[KEYLIST.index(elem)])
-            if ll < pickY < ul:
-                possible_key += elem
-                possible_val += [self.plotstream.ndarray[KEYLIST.index(elem)][idx]]
-        idy = (np.abs(possible_val - pickY)).argmin()
-        key = possible_key[idy]
-        val = possible_val[idy]
-        colname = self.plotstream.header.get('col-'+key, '')
-        if not colname == '':
-            key = colname
-        self.changeStatusbar("time: " + str(time) + "  |  " + key + " data value: " + str(val))
+        try:
+            for elem in self.shownkeylist:
+                ul = np.nanmax(self.plotstream.ndarray[KEYLIST.index(elem)])
+                ll = np.nanmin(self.plotstream.ndarray[KEYLIST.index(elem)])
+                if ll < pickY < ul:
+                    possible_key += elem
+                    possible_val += [self.plotstream.ndarray[KEYLIST.index(elem)][idx]]
+            idy = (np.abs(possible_val - pickY)).argmin()
+            key = possible_key[idy]
+            val = possible_val[idy]
+            colname = self.plotstream.header.get('col-'+key, '')
+            if not colname == '':
+                key = colname
+            self.changeStatusbar("time: " + str(time) + "  |  " + key + " data value: " + str(val))
+        except:
+            self.changeStatusbar("time: " + str(time) + "  |  ? data value: ?")
 
     def OnCheckOpenLog(self, event):
         """
@@ -4043,7 +4051,7 @@ Suite 330, Boston, MA  02111-1307  USA"""
             fitfunc = self.options.get('fitfunction','spline')
             if fitfunc.startswith('poly'):
                 fitfunc = 'poly'
-            baselinefunc = self.plotstream.baseline(absstream,fitfunc=self.options.get('fitfunction','spline'), knotstep=float(self.options.get('fitknotstep','0.3')), fitdegree=int(self.options.get('fitdegree','5')))
+            baselinefunc = self.plotstream.baseline(absstream,fitfunc=fitfunc, knotstep=float(self.options.get('fitknotstep','0.3')), fitdegree=int(self.options.get('fitdegree','5')))
             #keys = self.shownkeylist
             self.menu_p.rep_page.logMsg('- baseline adoption performed using DI data from {}. Parameters: function={}, knotsteps(spline)={}, degree(polynomial)={}'.format(basedict['filename'],self.options.get('fitfunction',''),self.options.get('fitknotstep',''),self.options.get('fitdegree','')))
             # add new stream, with baselinecorr
@@ -5117,7 +5125,46 @@ Suite 330, Boston, MA  02111-1307  USA"""
         dlg.Destroy()
 
     def onLoadUSGS(self,event):
-        print('Start')
+        startdate = self.plotstream.ndarray[KEYLIST.index('time')][0]
+        enddate = self.plotstream.ndarray[KEYLIST.index('time')][-1]
+        starttime = num2date(startdate)
+        endtime = num2date(enddate)
+        #if endtime - starttime < timedelta(days=5):
+        #    endtime = endtime+timedelta(days=5)
+        di_db = []
+        time = starttime - timedelta(days = 4)
+        base = 'https://geomag.usgs.gov/baselines/observation.json.php?'
+        observatory = self.plotstream.header.get('StationID')
+        while time < endtime + timedelta(days = 7):
+            called_date = time.strftime('%Y-%m-%d')
+            time = time + timedelta(days=1)
+            url = base + 'observatory=' + observatory + '&starttime=' + \
+                    called_date + '&includemeasurements=true'
+            di_db += [url]
+        self.menu_p.rep_page.logMsg("- loaded DI data")
+        self.menu_p.abs_page.diTextCtrl.SetValue('  '.join(di_db))
+        self.dipathlist = di_db
+        self.options['dipathlist'] = di_db
+        vario_scalar = self.menu_p.str_page.pathTextCtrl.GetValue()
+        self.menu_p.abs_page.varioTextCtrl.SetValue(vario_scalar)
+        self.options['divariopath'] = vario_scalar
+        self.menu_p.abs_page.scalarTextCtrl.SetValue(vario_scalar)
+        self.options['discalarpath'] = vario_scalar
+        self.menu_p.abs_page.AnalyzeButton.Enable()
+        # remove defaults
+        dlg = DISetParameterDialog(None, title='Set Parameter')
+        dlg.expDTextCtrl.SetValue('')
+        dlg.azimuthTextCtrl.SetValue('')
+        dlg.pierTextCtrl.SetValue('')
+        dlg.alphaTextCtrl.SetValue('')
+        dlg.deltaFTextCtrl.SetValue('')
+        self.options['diexpD'] = dlg.expDTextCtrl.GetValue()
+        self.options['diazimuth'] = dlg.azimuthTextCtrl.GetValue()
+        self.options['dipier'] = dlg.pierTextCtrl.GetValue()
+        self.options['dialpha'] = dlg.alphaTextCtrl.GetValue()
+        self.options['dideltaF'] = dlg.deltaFTextCtrl.GetValue()
+        self.options['diexpI']=''
+
 
     def onDefineVario(self,event):
         """
@@ -5191,7 +5238,6 @@ Suite 330, Boston, MA  02111-1307  USA"""
             deltaI= float(self.options.get('dideltaI','0.0'))
         except:
             deltaI = 0.0
-
         if len(self.dipathlist) > 0:
             self.changeStatusbar("Processing DI data ... please be patient")
             #absstream = absoluteAnalysis(self.dipathlist,self.divariopath,self.discalarpath, expD=self.diexpD,expI=self.diexpI,diid=self.diid,stationid=self.stationid,abstype=self.ditype, azimuth=self.diazimuth,pier=self.dipier,alpha=self.dialpha,deltaF=self.dideltaF, dbadd=self.didbadd)
@@ -5228,6 +5274,9 @@ Suite 330, Boston, MA  02111-1307  USA"""
                 #self.ActivateControls(self.plotstream)
                 self.OnInitialPlot(self.plotstream)
                 #self.plotoptlist.append(self.plotopt)
+                if not str(self.menu_p.abs_page.dilogTextCtrl.GetValue()) == '':
+                    self.menu_p.abs_page.ClearLogButton.Enable()
+                    self.menu_p.abs_page.SaveLogButton.Enable()
             else:
                 if absstream:
                     self.ActivateControls(self.plotstream)

--- a/magpy/gui/magpy_gui.py
+++ b/magpy/gui/magpy_gui.py
@@ -5125,52 +5125,49 @@ Suite 330, Boston, MA  02111-1307  USA"""
         dlg.Destroy()
 
     def onLoadUSGS(self,event):
-        startdate = self.plotstream.ndarray[KEYLIST.index('time')][0]
-        enddate = self.plotstream.ndarray[KEYLIST.index('time')][-1]
-        starttime = num2date(startdate)
-        endtime = num2date(enddate)
         di_db = []
-        dlg = LoadUSGSDialog(None, title='Get USGS data')
+        dlg = LoadUSGSDialog(None, title='Get USGS data', stream=self.plotstream)
         if dlg.ShowModal() == wx.ID_OK:
-            extension = dlg.extensionComboBox.GetValue()
-            dt = extension[0]
-            dttype = extension[2]
-            if dttype == 'd':
-                dt = int(dt)
-            if dttype == 'w':
-                dt = int(dt) * 7
-            time = starttime - timedelta(days = dt)
-            base = 'https://geomag.usgs.gov/baselines/observation.json.php?'
-            observatory = self.plotstream.header.get('StationID')
-            while time < endtime + timedelta(days = dt):
-                called_date = time.strftime('%Y-%m-%d')
-                time = time + timedelta(days=1)
-                url = base + 'observatory=' + observatory + '&starttime=' + \
-                        called_date + '&includemeasurements=true'
-                di_db += [url]
-            self.menu_p.rep_page.logMsg("- loaded DI data")
-            self.menu_p.abs_page.diTextCtrl.SetValue('  '.join(di_db))
-            self.dipathlist = di_db
-            self.options['dipathlist'] = di_db
-            vario_scalar = self.menu_p.str_page.pathTextCtrl.GetValue()
-            self.menu_p.abs_page.varioTextCtrl.SetValue(vario_scalar)
-            self.options['divariopath'] = vario_scalar
-            self.menu_p.abs_page.scalarTextCtrl.SetValue(vario_scalar)
-            self.options['discalarpath'] = vario_scalar
-            self.menu_p.abs_page.AnalyzeButton.Enable()
-            # remove defaults
-            dlg = DISetParameterDialog(None, title='Set Parameter')
-            dlg.expDTextCtrl.SetValue('')
-            dlg.azimuthTextCtrl.SetValue('')
-            dlg.pierTextCtrl.SetValue('')
-            dlg.alphaTextCtrl.SetValue('')
-            dlg.deltaFTextCtrl.SetValue('')
-            self.options['diexpD'] = dlg.expDTextCtrl.GetValue()
-            self.options['diazimuth'] = dlg.azimuthTextCtrl.GetValue()
-            self.options['dipier'] = dlg.pierTextCtrl.GetValue()
-            self.options['dialpha'] = dlg.alphaTextCtrl.GetValue()
-            self.options['dideltaF'] = dlg.deltaFTextCtrl.GetValue()
-            self.options['diexpI']=''
+            di_db = dlg.urls
+            startvalue = dlg.startDatePicker.GetValue()
+            starttime = datetime.fromtimestamp(startvalue.GetTicks())
+            endvalue = dlg.endDatePicker.GetValue()
+            endtime = datetime.fromtimestamp(endvalue.GetTicks())
+            if endtime >= starttime:
+                self.menu_p.rep_page.logMsg("- loaded DI data")
+                try:
+                    self.menu_p.abs_page.diTextCtrl.SetValue('  '.join(di_db))
+                except:
+                    self.menu_p.abs_page.diTextCtrl.SetValue(di_db[0])
+                self.dipathlist = di_db
+                self.options['dipathlist'] = di_db
+                vario_scalar = self.menu_p.str_page.pathTextCtrl.GetValue()
+                self.menu_p.abs_page.varioTextCtrl.SetValue(vario_scalar)
+                self.options['divariopath'] = vario_scalar
+                self.menu_p.abs_page.scalarTextCtrl.SetValue(vario_scalar)
+                self.options['discalarpath'] = vario_scalar
+                self.menu_p.abs_page.AnalyzeButton.Enable()
+                # remove defaults
+                dlg = DISetParameterDialog(None, title='Set Parameter')
+                dlg.expDTextCtrl.SetValue('')
+                dlg.azimuthTextCtrl.SetValue('')
+                dlg.pierTextCtrl.SetValue('')
+                dlg.alphaTextCtrl.SetValue('')
+                dlg.deltaFTextCtrl.SetValue('')
+                self.options['diexpD'] = dlg.expDTextCtrl.GetValue()
+                self.options['diazimuth'] = dlg.azimuthTextCtrl.GetValue()
+                self.options['dipier'] = dlg.pierTextCtrl.GetValue()
+                self.options['dialpha'] = dlg.alphaTextCtrl.GetValue()
+                self.options['dideltaF'] = dlg.deltaFTextCtrl.GetValue()
+                self.options['diexpI']=''
+            else:
+                dlg = wx.MessageDialog(self, "Could not load data!\n"
+                            "Entered dates are out of order.\n"
+                            "Reverting to original dates.\n",
+                            "LoadUSGSData", wx.OK|wx.ICON_INFORMATION)
+                dlg.ShowModal()
+                dlg.Destroy()
+
 
     def onDefineVario(self,event):
         """

--- a/magpy/gui/magpy_gui.py
+++ b/magpy/gui/magpy_gui.py
@@ -321,7 +321,7 @@ class PlotPanel(scrolled.ScrolledPanel):
         PARAMETERS:
             kwargs:  - all plot args
         """
-        # moved to MARTAS 
+        # moved to MARTAS
         pass
 
 
@@ -995,6 +995,7 @@ class MainFrame(wx.Frame):
         #        DI Page
         # --------------------------
         self.Bind(wx.EVT_BUTTON, self.onLoadDI, self.menu_p.abs_page.loadDIButton)
+        self.Bind(wx.EVT_BUTTON, self.onLoadUSGS, self.menu_p.abs_page.loadUSGSButton)
         self.Bind(wx.EVT_BUTTON, self.onDefineVario, self.menu_p.abs_page.defineVarioButton)
         self.Bind(wx.EVT_BUTTON, self.onDefineScalar, self.menu_p.abs_page.defineScalarButton)
         self.Bind(wx.EVT_BUTTON, self.onDIAnalyze, self.menu_p.abs_page.AnalyzeButton)
@@ -1164,6 +1165,7 @@ class MainFrame(wx.Frame):
         # DI
         self.menu_p.abs_page.AnalyzeButton.Disable()       # activate if DI data is present i.e. diTextCtrl contains data
         self.menu_p.abs_page.loadDIButton.Enable()         # remain enabled
+        self.menu_p.abs_page.loadUSGSButton.Enable()       # remain enabled
         self.menu_p.abs_page.defineVarioButton.Enable()    # remain enabled
         self.menu_p.abs_page.defineScalarButton.Enable()   # remain enabled
         if PLATFORM.startswith('linux'):
@@ -4051,7 +4053,7 @@ Suite 330, Boston, MA  02111-1307  USA"""
                         "Adopted baseline", wx.OK|wx.ICON_INFORMATION)
             dlg.ShowModal()
             dlg.Destroy()
-            
+
             self.ActivateControls(self.plotstream)
             self.OnPlot(self.plotstream,self.shownkeylist)
             self.changeStatusbar("BC function available - Ready")
@@ -5114,6 +5116,8 @@ Suite 330, Boston, MA  02111-1307  USA"""
             self.menu_p.abs_page.AnalyzeButton.Enable()
         dlg.Destroy()
 
+    def onLoadUSGS(self,event):
+        print('Start')
 
     def onDefineVario(self,event):
         """
@@ -5342,7 +5346,7 @@ Suite 330, Boston, MA  02111-1307  USA"""
     # ################
     # ------------------------------------------------------------------------------------------
 
-    """     
+    """
     def onConnectMQTTButton(self, event):
         # start a subscribe to client call
         success = True
@@ -5443,7 +5447,7 @@ Suite 330, Boston, MA  02111-1307  USA"""
             self.menu_p.com_page.logMsg(' - IP: {}'.format(martasaddress))
             self.menu_p.com_page.coverageTextCtrl.Enable()    # always
             self.menu_p.com_page.frequSlider.Enable()         # always
-    """     
+    """
 
     def onConnectMARCOSButton(self, event):
         # active if database is connected
@@ -5554,7 +5558,7 @@ Suite 330, Boston, MA  02111-1307  USA"""
 
             self.changeStatusbar("Scanning for MQTT broadcasts ... approx 20 sec")
 
-            
+
 
             loopcnt = 0
             success = True

--- a/magpy/gui/magpy_gui.py
+++ b/magpy/gui/magpy_gui.py
@@ -5141,11 +5141,9 @@ Suite 330, Boston, MA  02111-1307  USA"""
         dlg.Destroy()
         dlg = LoadUSGSDialog(None, title='Get USGS data', stream=self.plotstream)
         if dlg.ShowModal() == wx.ID_OK:
-            di_db = dlg.urls
-            startvalue = dlg.startDatePicker.GetValue()
-            starttime = datetime.fromtimestamp(startvalue.GetTicks())
-            endvalue = dlg.endDatePicker.GetValue()
-            endtime = datetime.fromtimestamp(endvalue.GetTicks())
+            starttime = dlg.starttime
+            endtime = dlg.endtime
+            di_db = self.getUrls(starttime, endtime)
             if endtime >= starttime:
                 self.menu_p.rep_page.logMsg("- loaded DI data")
                 try:
@@ -5170,6 +5168,21 @@ Suite 330, Boston, MA  02111-1307  USA"""
                             "LoadUSGSData", wx.OK|wx.ICON_INFORMATION)
                 dlg.ShowModal()
                 dlg.Destroy()
+
+    def getUrls(self, starttime, endtime):
+        urls = []
+        obsid = self.plotstream.header.get('StationID', '')
+        # Dates from pickers
+        base = 'https://geomag.usgs.gov/baselines/observation.json.php?'
+        time = starttime
+        while time < endtime:
+            start = time.strftime('%Y-%m-%d')
+            time = time + timedelta(days=1)
+            end = time.strftime('%Y-%m-%d')
+            url = base + 'observatory=' + obsid + '&starttime=' + \
+                start + '&endtime=' + end + '&includemeasurements=true'
+            urls += [url]
+        return urls
 
     def onDefineVario(self,event):
         """
@@ -5255,9 +5268,9 @@ Suite 330, Boston, MA  02111-1307  USA"""
             if usgsdata == True:
                 if not azimuth == '':
                     azimuth = float(azimuth)
-                    absstream = absoluteAnalysis(self.dipathlist,divariopath,discalarpath, expD=expD,expI=expI,stationid=stationid,abstype=abstype, azimuth=azimuth,alpha=alpha,beta=beta,deltaD=deltaD,deltaI=deltaI,deltaF=deltaF, usgsdata=True)
+                    absstream = absoluteAnalysis(self.dipathlist,divariopath,discalarpath, expD=expD,expI=expI,stationid=stationid,abstype=abstype, azimuth=azimuth,alpha=alpha,beta=beta,deltaD=deltaD,deltaI=deltaI,deltaF=deltaF, datastream=self.plotstream)
                 else:
-                    absstream = absoluteAnalysis(self.dipathlist,divariopath,discalarpath, expD=expD,expI=expI,stationid=stationid,alpha=alpha,beta=beta,deltaD=deltaD,deltaI=deltaI,deltaF=deltaF, usgsdata=True)
+                    absstream = absoluteAnalysis(self.dipathlist,divariopath,discalarpath, expD=expD,expI=expI,stationid=stationid,alpha=alpha,beta=beta,deltaD=deltaD,deltaI=deltaI,deltaF=deltaF, datastream=self.plotstream)
             else:
                 if not azimuth == '':
                     azimuth = float(azimuth)


### PR DESCRIPTION
This implements the new `readJSONABS` function that will parse USGS json files. Clicking the *Load USGS data* button will create a DI data list based on the geomag baselines web service. Extending the start and end of the time range (based on the plotted data) will ensure that the available unique baseline data covers the time range of the plotted data.
To test:
- Open a USGS URL or file
- Navigate to the DI page
- Click Load USGS data
   - choose whether or not to extend the time range (not required for all data sets, but recommended)
- Click Analyze
- Stream Operations -> Select Active Stream...
    - Choose the original data
- Navigate to the Analysis page
- Click Baseline
   - To change type of fit: Options -> Basic initialization parameter
   - polynomial appears to work best
- Navigate to the Stream page
- Click Baseline Corr