### PR TITLE
Option to create a separate flagging page

### DIFF
--- a/magpy/gui/flaggingpage.py
+++ b/magpy/gui/flaggingpage.py
@@ -48,40 +48,30 @@ class FlaggingPage(wx.Panel):
         # A horizontal BoxSizer will contain the GridSizer (on the left)
         # and the logger text control (on the right):
         boxSizer = wx.BoxSizer(orient=wx.HORIZONTAL)
-
-        # Prepare some reusable arguments for calling sizer.Add():
-        expandOption = dict(flag=wx.EXPAND)
-        noOptions = dict()
-        emptySpace = ((0,0), noOptions)
-
-        elemlist = [(self.flagOptionsLabel, noOptions),
-                 ((0,0), noOptions),
+        elemlist = [(self.flagOptionsLabel, dict()),
+                 ((0,0), dict()),
                  (self.flagOutlierButton, dict(flag=wx.ALIGN_CENTER)),
                  (self.flagSelectionButton, dict(flag=wx.ALIGN_CENTER)),
                  (self.flagRangeButton, dict(flag=wx.ALIGN_CENTER)),
                  (self.flagDropButton, dict(flag=wx.ALIGN_CENTER)),
                  (self.flagMinButton, dict(flag=wx.ALIGN_CENTER)),
                  (self.flagMaxButton, dict(flag=wx.ALIGN_CENTER)),
-                 (self.xCheckBox, noOptions),
-                 (self.yCheckBox, noOptions),
-                 (self.zCheckBox, noOptions),
-                 (self.fCheckBox, noOptions),
-                 (self.flagIDText, noOptions),
-                 (self.flagIDComboBox, expandOption),
+                 (self.xCheckBox, dict()),
+                 (self.yCheckBox, dict()),
+                 (self.zCheckBox, dict()),
+                 (self.fCheckBox, dict()),
+                 (self.flagIDText, dict()),
+                 (self.flagIDComboBox, dict(flag=wx.EXPAND)),
                  (self.flagLoadButton, dict(flag=wx.ALIGN_CENTER)),
                  (self.flagSaveButton, dict(flag=wx.ALIGN_CENTER)),]
-
         # A GridSizer will contain the other controls:
         cols = 2
         rows = int(np.ceil(len(elemlist)/float(cols)))
         gridSizer = wx.FlexGridSizer(rows=rows, cols=cols, vgap=10, hgap=10)
-
         # Add the controls to the sizers:
         for control, options in elemlist:
             gridSizer.Add(control, **options)
-
         for control, options in \
                 [(gridSizer, dict(border=5, flag=wx.ALL))]:
             boxSizer.Add(control, **options)
-
         self.SetSizerAndFit(boxSizer)

--- a/magpy/gui/flaggingpage.py
+++ b/magpy/gui/flaggingpage.py
@@ -37,8 +37,8 @@ class FlaggingPage(wx.Panel):
         self.yCheckBox = wx.CheckBox(self,label="Y             ")
         self.zCheckBox = wx.CheckBox(self,label="Z             ")
         self.fCheckBox = wx.CheckBox(self,label="F             ")
-        self.FlagIDText = wx.StaticText(self,label="Select Min/Max Flag ID:")
-        self.FlagIDComboBox = wx.ComboBox(self, choices=self.flagidlist,
+        self.flagIDText = wx.StaticText(self,label="Select Min/Max Flag ID:")
+        self.flagIDComboBox = wx.ComboBox(self, choices=self.flagidlist,
             style=wx.CB_DROPDOWN, value=self.flagidlist[3],size=(160,-1))
         self.flagSelectionButton = wx.Button(self,-1,"Flag Selection",size=(160,30))
         self.flagDropButton = wx.Button(self,-1,"Drop flagged",size=(160,30))
@@ -70,8 +70,8 @@ class FlaggingPage(wx.Panel):
                  'self.yCheckBox, noOptions',
                  'self.zCheckBox, noOptions',
                  'self.fCheckBox, noOptions',
-                 'self.FlagIDText, noOptions',
-                 'self.FlagIDComboBox, expandOption',
+                 'self.flagIDText, noOptions',
+                 'self.flagIDComboBox, expandOption',
                  'self.flagLoadButton, dict(flag=wx.ALIGN_CENTER)',
                  'self.flagSaveButton, dict(flag=wx.ALIGN_CENTER)',]
 

--- a/magpy/gui/flaggingpage.py
+++ b/magpy/gui/flaggingpage.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from magpy.stream import *
 from magpy.absolutes import *
 from magpy.transfer import *
@@ -29,10 +27,10 @@ class FlaggingPage(wx.Panel):
     # Widgets
     def createControls(self):
         self.flagOptionsLabel = wx.StaticText(self, label="Flagging methods:")
-        self.flagOutlierButton = wx.Button(self,-1,"Flag Outlier",size=(160,30))
-        self.flagRangeButton = wx.Button(self,-1,"Flag Range",size=(160,30))
-        self.flagMinButton = wx.Button(self,-1,"Flag Minimum",size=(160,30))
-        self.flagMaxButton = wx.Button(self,-1,"Flag Maximum",size=(160,30))
+        self.flagOutlierButton = wx.Button(self,-1,"Flag Outlier",size=(160,25))
+        self.flagRangeButton = wx.Button(self,-1,"Flag Range",size=(160,25))
+        self.flagMinButton = wx.Button(self,-1,"Flag Minimum",size=(160,25))
+        self.flagMaxButton = wx.Button(self,-1,"Flag Maximum",size=(160,25))
         self.xCheckBox = wx.CheckBox(self,label="X             ")
         self.yCheckBox = wx.CheckBox(self,label="Y             ")
         self.zCheckBox = wx.CheckBox(self,label="Z             ")
@@ -40,46 +38,47 @@ class FlaggingPage(wx.Panel):
         self.flagIDText = wx.StaticText(self,label="Select Min/Max Flag ID:")
         self.flagIDComboBox = wx.ComboBox(self, choices=self.flagidlist,
             style=wx.CB_DROPDOWN, value=self.flagidlist[3],size=(160,-1))
-        self.flagSelectionButton = wx.Button(self,-1,"Flag Selection",size=(160,30))
-        self.flagDropButton = wx.Button(self,-1,"Drop flagged",size=(160,30))
-        self.flagLoadButton = wx.Button(self,-1,"Load flags",size=(160,30))
-        self.flagSaveButton = wx.Button(self,-1,"Save flags",size=(160,30))
+        self.flagSelectionButton = wx.Button(self,-1,"Flag Selection",size=(160,25))
+        self.flagDropButton = wx.Button(self,-1,"Drop flagged",size=(160,25))
+        self.flagLoadButton = wx.Button(self,-1,"Load flags",size=(160,25))
+        self.flagSaveButton = wx.Button(self,-1,"Save flags",size=(160,25))
 
 
     def doLayout(self):
         # A horizontal BoxSizer will contain the GridSizer (on the left)
         # and the logger text control (on the right):
         boxSizer = wx.BoxSizer(orient=wx.HORIZONTAL)
-        # A GridSizer will contain the other controls:
-        gridSizer = wx.FlexGridSizer(rows=8, cols=2, vgap=5, hgap=10)
 
         # Prepare some reusable arguments for calling sizer.Add():
         expandOption = dict(flag=wx.EXPAND)
         noOptions = dict()
-        emptySpace = '(0,0), noOptions'
+        emptySpace = ((0,0), noOptions)
 
-        elemlist = ['self.flagOptionsLabel, noOptions',
-                 '(0,0), noOptions',
-                 'self.flagOutlierButton, dict(flag=wx.ALIGN_CENTER)',
-                 'self.flagSelectionButton, dict(flag=wx.ALIGN_CENTER)',
-                 'self.flagRangeButton, dict(flag=wx.ALIGN_CENTER)',
-                 'self.flagDropButton, dict(flag=wx.ALIGN_CENTER)',
-                 'self.flagMinButton, dict(flag=wx.ALIGN_CENTER)',
-                 'self.flagMaxButton, dict(flag=wx.ALIGN_CENTER)',
-                 'self.xCheckBox, noOptions',
-                 'self.yCheckBox, noOptions',
-                 'self.zCheckBox, noOptions',
-                 'self.fCheckBox, noOptions',
-                 'self.flagIDText, noOptions',
-                 'self.flagIDComboBox, expandOption',
-                 'self.flagLoadButton, dict(flag=wx.ALIGN_CENTER)',
-                 'self.flagSaveButton, dict(flag=wx.ALIGN_CENTER)',]
+        elemlist = [(self.flagOptionsLabel, noOptions),
+                 ((0,0), noOptions),
+                 (self.flagOutlierButton, dict(flag=wx.ALIGN_CENTER)),
+                 (self.flagSelectionButton, dict(flag=wx.ALIGN_CENTER)),
+                 (self.flagRangeButton, dict(flag=wx.ALIGN_CENTER)),
+                 (self.flagDropButton, dict(flag=wx.ALIGN_CENTER)),
+                 (self.flagMinButton, dict(flag=wx.ALIGN_CENTER)),
+                 (self.flagMaxButton, dict(flag=wx.ALIGN_CENTER)),
+                 (self.xCheckBox, noOptions),
+                 (self.yCheckBox, noOptions),
+                 (self.zCheckBox, noOptions),
+                 (self.fCheckBox, noOptions),
+                 (self.flagIDText, noOptions),
+                 (self.flagIDComboBox, expandOption),
+                 (self.flagLoadButton, dict(flag=wx.ALIGN_CENTER)),
+                 (self.flagSaveButton, dict(flag=wx.ALIGN_CENTER)),]
+
+        # A GridSizer will contain the other controls:
+        cols = 2
+        rows = int(np.ceil(len(elemlist)/float(cols)))
+        gridSizer = wx.FlexGridSizer(rows=rows, cols=cols, vgap=10, hgap=10)
 
         # Add the controls to the sizers:
-        for elem in elemlist:
-            control = elem.split(', ')[0]
-            options = elem.split(', ')[1]
-            gridSizer.Add(eval(control), **eval(options))
+        for control, options in elemlist:
+            gridSizer.Add(control, **options)
 
         for control, options in \
                 [(gridSizer, dict(border=5, flag=wx.ALL))]:

--- a/magpy/gui/flaggingpage.py
+++ b/magpy/gui/flaggingpage.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+
+from magpy.stream import *
+from magpy.absolutes import *
+from magpy.transfer import *
+from magpy.database import *
+
+import wx
+
+from matplotlib.backends.backend_wxagg import FigureCanvasWxAgg as FigureCanvas
+from matplotlib.backends.backend_wx import NavigationToolbar2Wx
+from matplotlib.figure import Figure
+
+import wx.lib.masked as masked
+
+# Subclasses for Menu pages and their controls
+
+class FlaggingPage(wx.Panel):
+    def __init__(self, *args, **kwds):
+        wx.Panel.__init__(self, *args, **kwds)
+        self.flagidlist = ['0: normal data',
+                        '1: automatically flagged',
+                        '2: keep data in any case',
+                        '3: remove data',
+                        '4: special flag']
+        self.createControls()
+        self.doLayout()
+
+    # Widgets
+    def createControls(self):
+        self.flagOptionsLabel = wx.StaticText(self, label="Flagging methods:")
+        self.flagOutlierButton = wx.Button(self,-1,"Flag Outlier",size=(160,30))
+        self.flagRangeButton = wx.Button(self,-1,"Flag Range",size=(160,30))
+        self.flagMinButton = wx.Button(self,-1,"Flag Minimum",size=(160,30))
+        self.flagMaxButton = wx.Button(self,-1,"Flag Maximum",size=(160,30))
+        self.xCheckBox = wx.CheckBox(self,label="X             ")
+        self.yCheckBox = wx.CheckBox(self,label="Y             ")
+        self.zCheckBox = wx.CheckBox(self,label="Z             ")
+        self.fCheckBox = wx.CheckBox(self,label="F             ")
+        self.FlagIDText = wx.StaticText(self,label="Select Min/Max Flag ID:")
+        self.FlagIDComboBox = wx.ComboBox(self, choices=self.flagidlist,
+            style=wx.CB_DROPDOWN, value=self.flagidlist[3],size=(160,-1))
+        self.flagSelectionButton = wx.Button(self,-1,"Flag Selection",size=(160,30))
+        self.flagDropButton = wx.Button(self,-1,"Drop flagged",size=(160,30))
+        self.flagLoadButton = wx.Button(self,-1,"Load flags",size=(160,30))
+        self.flagSaveButton = wx.Button(self,-1,"Save flags",size=(160,30))
+
+
+    def doLayout(self):
+        # A horizontal BoxSizer will contain the GridSizer (on the left)
+        # and the logger text control (on the right):
+        boxSizer = wx.BoxSizer(orient=wx.HORIZONTAL)
+        # A GridSizer will contain the other controls:
+        gridSizer = wx.FlexGridSizer(rows=8, cols=2, vgap=5, hgap=10)
+
+        # Prepare some reusable arguments for calling sizer.Add():
+        expandOption = dict(flag=wx.EXPAND)
+        noOptions = dict()
+        emptySpace = '(0,0), noOptions'
+
+        elemlist = ['self.flagOptionsLabel, noOptions',
+                 '(0,0), noOptions',
+                 'self.flagOutlierButton, dict(flag=wx.ALIGN_CENTER)',
+                 'self.flagSelectionButton, dict(flag=wx.ALIGN_CENTER)',
+                 'self.flagRangeButton, dict(flag=wx.ALIGN_CENTER)',
+                 'self.flagDropButton, dict(flag=wx.ALIGN_CENTER)',
+                 'self.flagMinButton, dict(flag=wx.ALIGN_CENTER)',
+                 'self.flagMaxButton, dict(flag=wx.ALIGN_CENTER)',
+                 'self.xCheckBox, noOptions',
+                 'self.yCheckBox, noOptions',
+                 'self.zCheckBox, noOptions',
+                 'self.fCheckBox, noOptions',
+                 'self.FlagIDText, noOptions',
+                 'self.FlagIDComboBox, expandOption',
+                 'self.flagLoadButton, dict(flag=wx.ALIGN_CENTER)',
+                 'self.flagSaveButton, dict(flag=wx.ALIGN_CENTER)',]
+
+        # Add the controls to the sizers:
+        for elem in elemlist:
+            control = elem.split(', ')[0]
+            options = elem.split(', ')[1]
+            gridSizer.Add(eval(control), **eval(options))
+
+        for control, options in \
+                [(gridSizer, dict(border=5, flag=wx.ALL))]:
+            boxSizer.Add(control, **options)
+
+        self.SetSizerAndFit(boxSizer)

--- a/magpy/gui/magpy_gui.py
+++ b/magpy/gui/magpy_gui.py
@@ -952,6 +952,9 @@ class MainFrame(wx.Frame):
         self.Bind(wx.EVT_BUTTON, self.onApplyBCButton, self.menu_p.str_page.applyBCButton)
         self.Bind(wx.EVT_RADIOBOX, self.onChangeComp, self.menu_p.str_page.compRadioBox)
         self.Bind(wx.EVT_RADIOBOX, self.onChangeSymbol, self.menu_p.str_page.symbolRadioBox)
+
+        #       Flagging Page
+        # ------------------------
         self.Bind(wx.EVT_BUTTON, self.onFlagOutlierButton, self.menu_p.flg_page.flagOutlierButton)
         self.Bind(wx.EVT_BUTTON, self.onFlagSelectionButton, self.menu_p.flg_page.flagSelectionButton)
         self.Bind(wx.EVT_BUTTON, self.onFlagRangeButton, self.menu_p.flg_page.flagRangeButton)
@@ -960,6 +963,7 @@ class MainFrame(wx.Frame):
         self.Bind(wx.EVT_BUTTON, self.onFlagDropButton, self.menu_p.flg_page.flagDropButton)
         self.Bind(wx.EVT_BUTTON, self.onFlagMinButton, self.menu_p.flg_page.flagMinButton)
         self.Bind(wx.EVT_BUTTON, self.onFlagMaxButton, self.menu_p.flg_page.flagMaxButton)
+
 
         #        Meta Page
         # --------------------------
@@ -1133,6 +1137,15 @@ class MainFrame(wx.Frame):
         self.menu_p.str_page.selectKeysButton.Disable()    # always
         self.menu_p.str_page.extractValuesButton.Disable() # always
         self.menu_p.str_page.changePlotButton.Disable()    # always
+        self.menu_p.str_page.dailyMeansButton.Disable()    # activated for DI data
+        self.menu_p.str_page.applyBCButton.Disable()       # activated if DataAbsInfo is present
+        self.menu_p.str_page.annotateCheckBox.Disable()    # activated if annotation are present
+        self.menu_p.str_page.errorBarsCheckBox.Disable()   # activated delta columns are present and not DI file
+        self.menu_p.str_page.confinexCheckBox.Disable()    # always
+        self.menu_p.str_page.compRadioBox.Disable()        # activated if xyz,hdz or idf
+        self.menu_p.str_page.symbolRadioBox.Disable()      # activated if less then 2000 points, active if DI data
+
+        # Flagging
         self.menu_p.flg_page.flagOutlierButton.Disable()   # always
         self.menu_p.flg_page.flagSelectionButton.Disable() # always
         self.menu_p.flg_page.flagRangeButton.Disable()     # always
@@ -1146,13 +1159,6 @@ class MainFrame(wx.Frame):
         self.menu_p.flg_page.flagIDComboBox.Disable()      # always
         self.menu_p.flg_page.flagDropButton.Disable()      # activated if annotation are present
         self.menu_p.flg_page.flagSaveButton.Disable()      # activated if annotation are present
-        self.menu_p.str_page.dailyMeansButton.Disable()    # activated for DI data
-        self.menu_p.str_page.applyBCButton.Disable()       # activated if DataAbsInfo is present
-        self.menu_p.str_page.annotateCheckBox.Disable()    # activated if annotation are present
-        self.menu_p.str_page.errorBarsCheckBox.Disable()   # activated delta columns are present and not DI file
-        self.menu_p.str_page.confinexCheckBox.Disable()    # always
-        self.menu_p.str_page.compRadioBox.Disable()        # activated if xyz,hdz or idf
-        self.menu_p.str_page.symbolRadioBox.Disable()      # activated if less then 2000 points, active if DI data
 
         # Meta
         self.menu_p.met_page.getDBButton.Disable()         # activated when DB is connected
@@ -1360,6 +1366,13 @@ class MainFrame(wx.Frame):
         self.menu_p.str_page.selectKeysButton.Enable()    # always
         self.menu_p.str_page.extractValuesButton.Enable() # always
         self.menu_p.str_page.changePlotButton.Enable()    # always
+        self.menu_p.str_page.confinexCheckBox.Enable()    # always
+        self.menu_p.met_page.MetaDataButton.Enable()      # always
+        self.menu_p.met_page.MetaSensorButton.Enable()    # always
+        self.menu_p.met_page.MetaStationButton.Enable()   # always
+
+        # ----------------------------------------
+        # flagging page
         self.menu_p.flg_page.flagOutlierButton.Enable()   # always
         self.menu_p.flg_page.flagSelectionButton.Enable() # always
         self.menu_p.flg_page.flagRangeButton.Enable()     # always
@@ -1367,10 +1380,6 @@ class MainFrame(wx.Frame):
         self.menu_p.flg_page.flagMinButton.Enable()       # always
         self.menu_p.flg_page.flagMaxButton.Enable()       # always
         self.menu_p.flg_page.flagIDComboBox.Enable()      # always
-        self.menu_p.str_page.confinexCheckBox.Enable()    # always
-        self.menu_p.met_page.MetaDataButton.Enable()      # always
-        self.menu_p.met_page.MetaSensorButton.Enable()    # always
-        self.menu_p.met_page.MetaStationButton.Enable()   # always
 
         # ----------------------------------------
         # analysis page
@@ -1641,7 +1650,7 @@ class MainFrame(wx.Frame):
         self.plot_p.guiPlot([self.plotstream],[keylist], plotopt=self.plotopt)
         boxes = ['x','y','z','f']
         for box in boxes:
-            checkbox = getattr(self.menu_p.str_page, box + 'CheckBox')
+            checkbox = getattr(self.menu_p.flg_page, box + 'CheckBox')
             if box in self.shownkeylist:
                 checkbox.Enable()
                 colname = self.plotstream.header.get('col-'+box, '')
@@ -1680,7 +1689,7 @@ class MainFrame(wx.Frame):
             self.ExportData.Enable(True)
         boxes = ['x','y','z','f']
         for box in boxes:
-            checkbox = getattr(self.menu_p.str_page, box + 'CheckBox')
+            checkbox = getattr(self.menu_p.flg_page, box + 'CheckBox')
             if box in self.shownkeylist:
                 checkbox.Enable()
                 colname = self.plotstream.header.get('col-'+box, '')
@@ -4870,7 +4879,7 @@ Suite 330, Boston, MA  02111-1307  USA"""
             comment = ''
         for idx,me in enumerate(mini):
             if keys[idx] is not 'df':
-                checkbox = getattr(self.menu_p.str_page, keys[idx] + 'CheckBox')
+                checkbox = getattr(self.menu_p.flg_page, keys[idx] + 'CheckBox')
                 if checkbox.IsChecked():
                     starttime = num2date(me[1] - xtol)
                     endtime = num2date(me[1] + xtol)
@@ -4907,7 +4916,7 @@ Suite 330, Boston, MA  02111-1307  USA"""
             comment = ''
         for idx,me in enumerate(maxi):
             if keys[idx] is not 'df':
-                checkbox = getattr(self.menu_p.str_page, keys[idx] + 'CheckBox')
+                checkbox = getattr(self.menu_p.flg_page, keys[idx] + 'CheckBox')
                 if checkbox.IsChecked():
                     starttime = num2date(me[1] - xtol)
                     endtime = num2date(me[1] + xtol)

--- a/magpy/gui/magpy_gui.py
+++ b/magpy/gui/magpy_gui.py
@@ -26,6 +26,7 @@ from magpy.transfer import *
 from magpy.database import *
 from magpy.version import __version__
 from magpy.gui.streampage import *
+from magpy.gui.flaggingpage import *
 from magpy.gui.metapage import *
 from magpy.gui.dialogclasses import *
 from magpy.gui.absolutespage import *
@@ -752,12 +753,14 @@ class MenuPanel(scrolled.ScrolledPanel):
         # Create pages on MenuPanel
         nb = wx.Notebook(self,-1)
         self.str_page = StreamPage(nb)
+        self.flg_page = FlaggingPage(nb)
         self.met_page = MetaPage(nb)
         self.ana_page = AnalysisPage(nb)
         self.abs_page = AbsolutePage(nb)
         self.rep_page = ReportPage(nb)
         self.com_page = MonitorPage(nb)
         nb.AddPage(self.str_page, "Stream")
+        nb.AddPage(self.flg_page, "Flagging")
         nb.AddPage(self.met_page, "Meta")
         nb.AddPage(self.ana_page, "Analysis")
         nb.AddPage(self.abs_page, "DI")

--- a/magpy/gui/magpy_gui.py
+++ b/magpy/gui/magpy_gui.py
@@ -952,14 +952,14 @@ class MainFrame(wx.Frame):
         self.Bind(wx.EVT_BUTTON, self.onApplyBCButton, self.menu_p.str_page.applyBCButton)
         self.Bind(wx.EVT_RADIOBOX, self.onChangeComp, self.menu_p.str_page.compRadioBox)
         self.Bind(wx.EVT_RADIOBOX, self.onChangeSymbol, self.menu_p.str_page.symbolRadioBox)
-        self.Bind(wx.EVT_BUTTON, self.onFlagOutlierButton, self.menu_p.str_page.flagOutlierButton)
-        self.Bind(wx.EVT_BUTTON, self.onFlagSelectionButton, self.menu_p.str_page.flagSelectionButton)
-        self.Bind(wx.EVT_BUTTON, self.onFlagRangeButton, self.menu_p.str_page.flagRangeButton)
-        self.Bind(wx.EVT_BUTTON, self.onFlagLoadButton, self.menu_p.str_page.flagLoadButton)
-        self.Bind(wx.EVT_BUTTON, self.onFlagSaveButton, self.menu_p.str_page.flagSaveButton)
-        self.Bind(wx.EVT_BUTTON, self.onFlagDropButton, self.menu_p.str_page.flagDropButton)
-        self.Bind(wx.EVT_BUTTON, self.onFlagMinButton, self.menu_p.str_page.flagMinButton)
-        self.Bind(wx.EVT_BUTTON, self.onFlagMaxButton, self.menu_p.str_page.flagMaxButton)
+        self.Bind(wx.EVT_BUTTON, self.onFlagOutlierButton, self.menu_p.flg_page.flagOutlierButton)
+        self.Bind(wx.EVT_BUTTON, self.onFlagSelectionButton, self.menu_p.flg_page.flagSelectionButton)
+        self.Bind(wx.EVT_BUTTON, self.onFlagRangeButton, self.menu_p.flg_page.flagRangeButton)
+        self.Bind(wx.EVT_BUTTON, self.onFlagLoadButton, self.menu_p.flg_page.flagLoadButton)
+        self.Bind(wx.EVT_BUTTON, self.onFlagSaveButton, self.menu_p.flg_page.flagSaveButton)
+        self.Bind(wx.EVT_BUTTON, self.onFlagDropButton, self.menu_p.flg_page.flagDropButton)
+        self.Bind(wx.EVT_BUTTON, self.onFlagMinButton, self.menu_p.flg_page.flagMinButton)
+        self.Bind(wx.EVT_BUTTON, self.onFlagMaxButton, self.menu_p.flg_page.flagMaxButton)
 
         #        Meta Page
         # --------------------------
@@ -1133,19 +1133,19 @@ class MainFrame(wx.Frame):
         self.menu_p.str_page.selectKeysButton.Disable()    # always
         self.menu_p.str_page.extractValuesButton.Disable() # always
         self.menu_p.str_page.changePlotButton.Disable()    # always
-        self.menu_p.str_page.flagOutlierButton.Disable()   # always
-        self.menu_p.str_page.flagSelectionButton.Disable() # always
-        self.menu_p.str_page.flagRangeButton.Disable()     # always
-        self.menu_p.str_page.flagLoadButton.Disable()      # always
-        self.menu_p.str_page.flagMinButton.Disable()       # always
-        self.menu_p.str_page.flagMaxButton.Disable()       # always
-        self.menu_p.str_page.xCheckBox.Disable()           # always
-        self.menu_p.str_page.yCheckBox.Disable()           # always
-        self.menu_p.str_page.zCheckBox.Disable()           # always
-        self.menu_p.str_page.fCheckBox.Disable()           # always
-        self.menu_p.str_page.FlagIDComboBox.Disable()      # always
-        self.menu_p.str_page.flagDropButton.Disable()      # activated if annotation are present
-        self.menu_p.str_page.flagSaveButton.Disable()      # activated if annotation are present
+        self.menu_p.flg_page.flagOutlierButton.Disable()   # always
+        self.menu_p.flg_page.flagSelectionButton.Disable() # always
+        self.menu_p.flg_page.flagRangeButton.Disable()     # always
+        self.menu_p.flg_page.flagLoadButton.Disable()      # always
+        self.menu_p.flg_page.flagMinButton.Disable()       # always
+        self.menu_p.flg_page.flagMaxButton.Disable()       # always
+        self.menu_p.flg_page.xCheckBox.Disable()           # always
+        self.menu_p.flg_page.yCheckBox.Disable()           # always
+        self.menu_p.flg_page.zCheckBox.Disable()           # always
+        self.menu_p.flg_page.fCheckBox.Disable()           # always
+        self.menu_p.flg_page.flagIDComboBox.Disable()      # always
+        self.menu_p.flg_page.flagDropButton.Disable()      # activated if annotation are present
+        self.menu_p.flg_page.flagSaveButton.Disable()      # activated if annotation are present
         self.menu_p.str_page.dailyMeansButton.Disable()    # activated for DI data
         self.menu_p.str_page.applyBCButton.Disable()       # activated if DataAbsInfo is present
         self.menu_p.str_page.annotateCheckBox.Disable()    # activated if annotation are present
@@ -1360,13 +1360,13 @@ class MainFrame(wx.Frame):
         self.menu_p.str_page.selectKeysButton.Enable()    # always
         self.menu_p.str_page.extractValuesButton.Enable() # always
         self.menu_p.str_page.changePlotButton.Enable()    # always
-        self.menu_p.str_page.flagOutlierButton.Enable()   # always
-        self.menu_p.str_page.flagSelectionButton.Enable() # always
-        self.menu_p.str_page.flagRangeButton.Enable()     # always
-        self.menu_p.str_page.flagLoadButton.Enable()      # always
-        self.menu_p.str_page.flagMinButton.Enable()       # always
-        self.menu_p.str_page.flagMaxButton.Enable()       # always
-        self.menu_p.str_page.FlagIDComboBox.Enable()      # always
+        self.menu_p.flg_page.flagOutlierButton.Enable()   # always
+        self.menu_p.flg_page.flagSelectionButton.Enable() # always
+        self.menu_p.flg_page.flagRangeButton.Enable()     # always
+        self.menu_p.flg_page.flagLoadButton.Enable()      # always
+        self.menu_p.flg_page.flagMinButton.Enable()       # always
+        self.menu_p.flg_page.flagMaxButton.Enable()       # always
+        self.menu_p.flg_page.flagIDComboBox.Enable()      # always
         self.menu_p.str_page.confinexCheckBox.Enable()    # always
         self.menu_p.met_page.MetaDataButton.Enable()      # always
         self.menu_p.met_page.MetaSensorButton.Enable()    # always
@@ -1401,8 +1401,8 @@ class MainFrame(wx.Frame):
                 self.compselect = 'xyz'
 
         if len(commcol) > 0:
-            self.menu_p.str_page.flagDropButton.Enable()     # activated if annotation are present
-            self.menu_p.str_page.flagSaveButton.Enable()      # activated if annotation are present
+            self.menu_p.flg_page.flagDropButton.Enable()     # activated if annotation are present
+            self.menu_p.flg_page.flagSaveButton.Enable()      # activated if annotation are present
             self.menu_p.str_page.annotateCheckBox.Enable()    # activated if annotation are present
             if self.menu_p.str_page.annotateCheckBox.GetValue():
                 self.menu_p.str_page.annotateCheckBox.SetValue(True)
@@ -4864,7 +4864,7 @@ Suite 330, Boston, MA  02111-1307  USA"""
         mini = [teststream._get_min(key,returntime=True) for key in keys]
         flaglist = []
         comment = 'Flagged minimum'
-        flagid = self.menu_p.str_page.FlagIDComboBox.GetValue()
+        flagid = self.menu_p.flg_page.flagIDComboBox.GetValue()
         flagid = int(flagid[0])
         if flagid is 0:
             comment = ''
@@ -4901,7 +4901,7 @@ Suite 330, Boston, MA  02111-1307  USA"""
         maxi = [teststream._get_max(key,returntime=True) for key in keys]
         flaglist = []
         comment = 'Flagged maximum'
-        flagid = self.menu_p.str_page.FlagIDComboBox.GetValue()
+        flagid = self.menu_p.flg_page.flagIDComboBox.GetValue()
         flagid = int(flagid[0])
         if flagid is 0:
             comment = ''

--- a/magpy/gui/streampage.py
+++ b/magpy/gui/streampage.py
@@ -20,11 +20,6 @@ class StreamPage(wx.Panel):
         wx.Panel.__init__(self, *args, **kwds)
         self.comp = ['xyz', 'hdz', 'idf']
         self.symbol = ['line', 'point']
-        self.flagidlist = ['0: normal data',
-                        '1: automatically flagged',
-                        '2: keep data in any case',
-                        '3: remove data',
-                        '4: special flag']
         self.createControls()
         self.doLayout()
 
@@ -47,28 +42,12 @@ class StreamPage(wx.Panel):
         self.endTimePicker = wx.TextCtrl(self, value=datetime.now().strftime('%X'))
         self.trimStreamButton = wx.Button(self,-1,"Trim timerange",size=(160,30))
         self.plotOptionsLabel = wx.StaticText(self, label="Plotting options:")
-        self.flagOptionsLabel = wx.StaticText(self, label="Flagging methods:")
         self.selectKeysButton = wx.Button(self,-1,"Select Columns",size=(160,30))
         self.extractValuesButton = wx.Button(self,-1,"Extract Values",size=(160,30))
         self.restoreButton = wx.Button(self,-1,"Restore data",size=(160,30))
         self.changePlotButton = wx.Button(self,-1,"Plot Options",size=(160,30))
         self.dailyMeansButton = wx.Button(self,-1,"Daily Means",size=(160,30))
         self.applyBCButton = wx.Button(self,-1,"Baseline Corr",size=(160,30))
-        self.flagOutlierButton = wx.Button(self,-1,"Flag Outlier",size=(160,30))
-        self.flagRangeButton = wx.Button(self,-1,"Flag Range",size=(160,30))
-        self.flagMinButton = wx.Button(self,-1,"Flag Minimum",size=(160,30))
-        self.flagMaxButton = wx.Button(self,-1,"Flag Maximum",size=(160,30))
-        self.xCheckBox = wx.CheckBox(self,label="X             ")
-        self.yCheckBox = wx.CheckBox(self,label="Y             ")
-        self.zCheckBox = wx.CheckBox(self,label="Z             ")
-        self.fCheckBox = wx.CheckBox(self,label="F             ")
-        self.FlagIDText = wx.StaticText(self,label="Select Min/Max Flag ID:")
-        self.FlagIDComboBox = wx.ComboBox(self, choices=self.flagidlist,
-            style=wx.CB_DROPDOWN, value=self.flagidlist[3],size=(160,-1))
-        self.flagSelectionButton = wx.Button(self,-1,"Flag Selection",size=(160,30))
-        self.flagDropButton = wx.Button(self,-1,"Drop flagged",size=(160,30))
-        self.flagLoadButton = wx.Button(self,-1,"Load flags",size=(160,30))
-        self.flagSaveButton = wx.Button(self,-1,"Save flags",size=(160,30))
         self.compRadioBox = wx.RadioBox(self,
             label="Select components",
             choices=self.comp, majorDimension=3, style=wx.RA_SPECIFY_COLS)
@@ -88,7 +67,7 @@ class StreamPage(wx.Panel):
         # and the logger text control (on the right):
         boxSizer = wx.BoxSizer(orient=wx.HORIZONTAL)
         # A GridSizer will contain the other controls:
-        gridSizer = wx.FlexGridSizer(rows=28, cols=2, vgap=5, hgap=10)
+        gridSizer = wx.FlexGridSizer(rows=16, cols=2, vgap=5, hgap=10)
 
         # Prepare some reusable arguments for calling sizer.Add():
         expandOption = dict(flag=wx.EXPAND)
@@ -126,25 +105,7 @@ class StreamPage(wx.Panel):
                  'self.errorBarsCheckBox, noOptions',
                  '(0,0), noOptions',
                  'self.lineLabel3, noOptions',
-                 'self.lineLabel4, noOptions',
-                 'self.flagOptionsLabel, noOptions',
-                 '(0,0), noOptions',
-                 'self.flagOutlierButton, dict(flag=wx.ALIGN_CENTER)',
-                 'self.flagSelectionButton, dict(flag=wx.ALIGN_CENTER)',
-                 'self.flagRangeButton, dict(flag=wx.ALIGN_CENTER)',
-                 'self.flagDropButton, dict(flag=wx.ALIGN_CENTER)',
-                 'self.flagMinButton, dict(flag=wx.ALIGN_CENTER)',
-                 'self.flagMaxButton, dict(flag=wx.ALIGN_CENTER)',
-                 'self.xCheckBox, noOptions',
-                 'self.yCheckBox, noOptions',
-                 'self.zCheckBox, noOptions',
-                 'self.fCheckBox, noOptions',
-                 'self.FlagIDText, noOptions',
-                 'self.FlagIDComboBox, expandOption',
-                 'self.flagLoadButton, dict(flag=wx.ALIGN_CENTER)',
-                 'self.flagSaveButton, dict(flag=wx.ALIGN_CENTER)',
-                 '(0,0), noOptions',
-                 '(0,0), noOptions']
+                 'self.lineLabel4, noOptions',]
 
 
         # modify look: ReDraw connected to radio and check boxes with dates


### PR DESCRIPTION
Due to the large number of buttons on the stream page, it can be difficult to access the entire page on a smaller screen. This option separates the flagging buttons from the stream page in order to organize and declutter the pages.


**Before:**
![before](https://user-images.githubusercontent.com/26904055/31747059-eafef132-b427-11e7-95a8-0e792f51f079.png)

**After:**
![after1](https://user-images.githubusercontent.com/26904055/31747073-ff31db24-b427-11e7-801b-74723ab27306.png)
![after2](https://user-images.githubusercontent.com/26904055/31747074-ff458142-b427-11e7-8264-b6159c6fc2d1.png)