### PR TITLE
Add statistics text control panel

### DIFF
--- a/magpy/gui/analysispage.py
+++ b/magpy/gui/analysispage.py
@@ -69,6 +69,9 @@ class AnalysisPage(wx.Panel):
         # 5 Line
         self.powerButton = wx.Button(self,-1,"Power",size=(160,30))
         self.spectrumButton = wx.Button(self,-1,"Spectrum",size=(160,30))
+        self.statisticsLabel = wx.StaticText(self, label="Statistics:")
+        self.statisticsTextCtrl = wx.TextCtrl(self, wx.ID_ANY, size=(250,150),
+                style = wx.TE_MULTILINE|wx.TE_READONLY|wx.HSCROLL|wx.VSCROLL)
 
         # 5 Line
         #self.mergeButton = wx.Button(self,-1,"Merge",size=(160,30))
@@ -137,11 +140,66 @@ class AnalysisPage(wx.Panel):
                  (self.head5Label, noOptions),
                   emptySpace,
                  (self.powerButton, dict(flag=wx.ALIGN_CENTER)),
-                 (self.spectrumButton, dict(flag=wx.ALIGN_CENTER))]:
+                 (self.spectrumButton, dict(flag=wx.ALIGN_CENTER)),
+                 emptySpace]:
             gridSizer.Add(control, **options)
 
         for control, options in \
                 [(gridSizer, dict(border=5, flag=wx.ALL))]:
             boxSizer.Add(control, **options)
 
-        self.SetSizerAndFit(boxSizer)
+        mainSizer = wx.BoxSizer(wx.VERTICAL)
+        mainSizer.Add(boxSizer, 0, 0, 0)
+
+        mainSizer.Add(self.statisticsLabel, 0, wx.ALIGN_LEFT | wx.ALL, 3)
+        mainSizer.Add(self.statisticsTextCtrl, 1, wx.SHAPED, 3)
+        self.SetSizerAndFit(mainSizer)
+
+    def getMin(self, keys, teststream):
+        mini = [teststream._get_min(key,returntime=True) for key in keys]
+        mintext = '\n-------------------Minimum-------------------'
+        for idx,me in enumerate(mini):
+            line = '{} minima = {} at {}'.format(keys[idx],
+                    me[0], num2date(me[1]))
+            mintext = mintext + '\n' + line
+        return mintext
+
+    def getMax(self, keys, teststream):
+        maxi = [teststream._get_max(key,returntime=True) for key in keys]
+        maxtext = '\n-------------------Maximum-------------------'
+        for idx,me in enumerate(maxi):
+            line = '{} maxima = {} at {}'.format(keys[idx],
+                    me[0], num2date(me[1]))
+            maxtext = maxtext + '\n' + line
+        return maxtext
+
+    def getMean(self, keys, teststream):
+        mean = [teststream.mean(key,meanfunction='mean',std=True,percentage=10) for key in keys]
+        meantext = '\n--------------------Mean--------------------'
+        for idx,me in enumerate(mean):
+            line = '{} mean = {} at {}'.format(keys[idx],
+                    me[0], me[1])
+            meantext = meantext + '\n' + line
+        return meantext
+
+    def getVariance(self, keys, teststream):
+        var = [teststream._get_variance(key) for key in keys]
+        vartext = '\n-------------------Variance------------------'
+        for idx,me in enumerate(var):
+            line = '{} variance = {}'.format(keys[idx], me)
+            vartext = vartext + '\n' + line
+        return vartext
+
+    def setStatistics(self, keys, stream, xlimits):
+        testarray = stream._select_timerange(starttime=xlimits[0],
+                endtime=xlimits[1])
+        teststream = DataStream([LineStruct()], stream, testarray)
+        t_limits = teststream._find_t_limits()
+        trange = 'Timerange: {} to {}'.format(t_limits[0],
+                t_limits[1])
+        mintext = self.getMin(keys, teststream)
+        maxtext = self.getMax(keys, teststream)
+        meantext = self.getMean(keys, teststream)
+        vartext = self.getVariance(keys, teststream)
+        stats = trange + mintext + maxtext + meantext + vartext
+        self.statisticsTextCtrl.SetValue(stats)

--- a/magpy/gui/analysispage.py
+++ b/magpy/gui/analysispage.py
@@ -46,6 +46,8 @@ class AnalysisPage(wx.Panel):
         self.head5Label = wx.StaticText(self, label="Frequency range:")
         #self.head5Label = wx.StaticText(self, label="Multiple streams:")
         # merge, subtract, stack
+        # display continuous statistics
+        self.head6Label = wx.StaticText(self, label="Continuous statistics:")
 
         # 1 Line
         self.derivativeButton = wx.Button(self,-1,"Derivative",size=(160,30))
@@ -69,9 +71,8 @@ class AnalysisPage(wx.Panel):
         # 5 Line
         self.powerButton = wx.Button(self,-1,"Power",size=(160,30))
         self.spectrumButton = wx.Button(self,-1,"Spectrum",size=(160,30))
-        self.statisticsLabel = wx.StaticText(self, label="Statistics:")
-        self.statisticsTextCtrl = wx.TextCtrl(self, wx.ID_ANY, size=(250,150),
-                style = wx.TE_MULTILINE|wx.TE_READONLY|wx.HSCROLL|wx.VSCROLL)
+        # 6 Line
+        self.statsButton = wx.Button(self,-1,"Show Statistics",size=(160,30))
 
         # 5 Line
         #self.mergeButton = wx.Button(self,-1,"Merge",size=(160,30))
@@ -141,6 +142,11 @@ class AnalysisPage(wx.Panel):
                   emptySpace,
                  (self.powerButton, dict(flag=wx.ALIGN_CENTER)),
                  (self.spectrumButton, dict(flag=wx.ALIGN_CENTER)),
+                 emptySpace,
+                 emptySpace,
+                 (self.head6Label, noOptions),
+                 emptySpace,
+                 (self.statsButton, dict(flag=wx.ALIGN_CENTER)),
                  emptySpace]:
             gridSizer.Add(control, **options)
 
@@ -148,58 +154,4 @@ class AnalysisPage(wx.Panel):
                 [(gridSizer, dict(border=5, flag=wx.ALL))]:
             boxSizer.Add(control, **options)
 
-        mainSizer = wx.BoxSizer(wx.VERTICAL)
-        mainSizer.Add(boxSizer, 0, 0, 0)
-
-        mainSizer.Add(self.statisticsLabel, 0, wx.ALIGN_LEFT | wx.ALL, 3)
-        mainSizer.Add(self.statisticsTextCtrl, 1, wx.SHAPED, 3)
-        self.SetSizerAndFit(mainSizer)
-
-    def getMin(self, keys, teststream):
-        mini = [teststream._get_min(key,returntime=True) for key in keys]
-        mintext = '\n-------------------Minimum-------------------'
-        for idx,me in enumerate(mini):
-            line = '{} minima = {} at {}'.format(keys[idx],
-                    me[0], num2date(me[1]))
-            mintext = mintext + '\n' + line
-        return mintext
-
-    def getMax(self, keys, teststream):
-        maxi = [teststream._get_max(key,returntime=True) for key in keys]
-        maxtext = '\n-------------------Maximum-------------------'
-        for idx,me in enumerate(maxi):
-            line = '{} maxima = {} at {}'.format(keys[idx],
-                    me[0], num2date(me[1]))
-            maxtext = maxtext + '\n' + line
-        return maxtext
-
-    def getMean(self, keys, teststream):
-        mean = [teststream.mean(key,meanfunction='mean',std=True,percentage=10) for key in keys]
-        meantext = '\n--------------------Mean--------------------'
-        for idx,me in enumerate(mean):
-            line = '{} mean = {} at {}'.format(keys[idx],
-                    me[0], me[1])
-            meantext = meantext + '\n' + line
-        return meantext
-
-    def getVariance(self, keys, teststream):
-        var = [teststream._get_variance(key) for key in keys]
-        vartext = '\n-------------------Variance------------------'
-        for idx,me in enumerate(var):
-            line = '{} variance = {}'.format(keys[idx], me)
-            vartext = vartext + '\n' + line
-        return vartext
-
-    def setStatistics(self, keys, stream, xlimits):
-        testarray = stream._select_timerange(starttime=xlimits[0],
-                endtime=xlimits[1])
-        teststream = DataStream([LineStruct()], stream, testarray)
-        t_limits = teststream._find_t_limits()
-        trange = 'Timerange: {} to {}'.format(t_limits[0],
-                t_limits[1])
-        mintext = self.getMin(keys, teststream)
-        maxtext = self.getMax(keys, teststream)
-        meantext = self.getMean(keys, teststream)
-        vartext = self.getVariance(keys, teststream)
-        stats = trange + mintext + maxtext + meantext + vartext
-        self.statisticsTextCtrl.SetValue(stats)
+        self.SetSizerAndFit(boxSizer)

--- a/magpy/gui/magpy_gui.py
+++ b/magpy/gui/magpy_gui.py
@@ -34,6 +34,7 @@ from magpy.gui.reportpage import *
 from magpy.gui.developpage import *  # remove this
 from magpy.gui.analysispage import *
 from magpy.gui.monitorpage import *
+from magpy.gui.statisticspage import StatisticsPanel
 import glob, os, pickle, base64
 import pylab
 import thread, time
@@ -778,8 +779,13 @@ class MainFrame(wx.Frame):
         wx.Frame.__init__(self, *args, **kwds)
         # The Splitted Window
         self.sp = wx.SplitterWindow(self, -1, style=wx.SP_3D|wx.SP_BORDER)
-        self.plot_p = PlotPanel(self.sp,-1)
-        self.menu_p = MenuPanel(self.sp,-1)
+        self.sp2 = wx.SplitterWindow(self.sp, -1, style=wx.SP_3D|wx.SP_BORDER)
+        self.plot_p = PlotPanel(self.sp2,-1)
+        self.menu_p = MenuPanel(self.sp2,-1)
+        self.sp2.SplitVertically(self.plot_p, self.menu_p, 800)
+        self.stats_p = StatisticsPanel(self.sp)
+        self.sp.SplitHorizontally(self.sp2, self.stats_p, 800)
+        self.sp.Unsplit(self.stats_p)
         pub.subscribe(self.changeStatusbar, 'changeStatusbar')
 
         # The Status Bar
@@ -998,6 +1004,7 @@ class MainFrame(wx.Frame):
         self.Bind(wx.EVT_BUTTON, self.onDeltafButton, self.menu_p.ana_page.deltafButton)
         self.Bind(wx.EVT_BUTTON, self.onPowerButton, self.menu_p.ana_page.powerButton)
         self.Bind(wx.EVT_BUTTON, self.onSpectrumButton, self.menu_p.ana_page.spectrumButton)
+        self.Bind(wx.EVT_BUTTON, self.onStatsButton, self.menu_p.ana_page.statsButton)
         #        DI Page
         # --------------------------
         self.Bind(wx.EVT_BUTTON, self.onLoadDI, self.menu_p.abs_page.loadDIButton)
@@ -1032,8 +1039,6 @@ class MainFrame(wx.Frame):
         # --------------------------
         self.DeactivateAllControls()
 
-        self.sp.SplitVertically(self.plot_p,self.menu_p,800)
-
     def __set_properties(self):
         self.SetTitle("MagPy")
         self.SetSize((1200, 800))
@@ -1045,7 +1050,7 @@ class MainFrame(wx.Frame):
             self.StatusBar.SetStatusText(StatusBar_fields[i], i)
         self.menu_p.SetMinSize((400, 750))
         self.plot_p.SetMinSize((100, 100))
-
+        self.stats_p.SetMinSize((100, 100))
 
     def InitPlotParameter(self, keylist = None):
         # Kwargs for plotting
@@ -1201,6 +1206,7 @@ class MainFrame(wx.Frame):
         self.menu_p.ana_page.deltafButton.Disable()        # if xyzf available
         self.menu_p.ana_page.powerButton.Disable()         # always
         self.menu_p.ana_page.spectrumButton.Disable()      # always
+        self.menu_p.ana_page.statsButton.Disable()         # always
         #self.menu_p.ana_page.mergeButton.Disable()         # if len(self.streamlist) > 1
         #self.menu_p.ana_page.subtractButton.Disable()      # if len(self.streamlist) > 1
         #self.menu_p.ana_page.stackButton.Disable()         # if len(self.streamlist) > 1
@@ -1395,7 +1401,7 @@ class MainFrame(wx.Frame):
         self.menu_p.ana_page.smoothButton.Enable()        # always
         self.menu_p.ana_page.powerButton.Enable()         # always
         self.menu_p.ana_page.spectrumButton.Enable()      # always
-
+        self.menu_p.ana_page.statsButton.Enable()      # always
         # ----------------------------------------
         # absolutes page
         self.menu_p.abs_page.loadUSGSButton.Enable()      # always
@@ -1663,6 +1669,7 @@ class MainFrame(wx.Frame):
                     checkbox.SetLabel(colname)
             else:
                 checkbox.SetValue(False)
+        # Connect callback to the initial plot
         for idx, ax in enumerate(self.plot_p.axlist):
             ax.callbacks.connect('xlim_changed', self.updateStatistics)
             ax.callbacks.connect('ylim_changed', self.updateStatistics)
@@ -1706,6 +1713,10 @@ class MainFrame(wx.Frame):
                     checkbox.SetLabel(colname)
             else:
                 checkbox.SetValue(False)
+        # Connect callback to the new plot
+        for idx, ax in enumerate(self.plot_p.axlist):
+            ax.callbacks.connect('xlim_changed', self.updateStatistics)
+            ax.callbacks.connect('ylim_changed', self.updateStatistics)
         self.updateStatistics()
         self.changeStatusbar("Ready")
 
@@ -2368,9 +2379,10 @@ Suite 330, Boston, MA  02111-1307  USA"""
         self.SetStatusText(msg)
 
     def updateStatistics(self, event=None):
-        self.menu_p.ana_page.setStatistics(keys=self.shownkeylist,
-                stream=self.plotstream.copy(),
-                xlimits=self.plot_p.xlimits)
+        if self.menu_p.ana_page.statsButton.GetLabel() == 'Hide Statistics':
+            self.stats_p.stats_page.setStatistics(keys=self.shownkeylist,
+                    stream=self.plotstream.copy(),
+                    xlimits=self.plot_p.xlimits)
 
 
     def UpdateCursorStatus(self, event):
@@ -4142,7 +4154,17 @@ Suite 330, Boston, MA  02111-1307  USA"""
         import magpy.mpplot as mp
         mp.plotSpectrogram(self.plotstream, comp)
 
-
+    def onStatsButton(self, event):
+        status = self.menu_p.ana_page.statsButton.GetLabel()
+        if status == 'Show Statistics':
+            self.sp.SplitHorizontally(self.sp2, self.stats_p, 800)
+            self.stats_p.stats_page.setStatistics(keys=self.shownkeylist,
+                    stream=self.plotstream.copy(),
+                    xlimits=self.plot_p.xlimits)
+            self.menu_p.ana_page.statsButton.SetLabel("Hide Statistics")
+        if status == 'Hide Statistics':
+            self.sp.Unsplit(self.stats_p)
+            self.menu_p.ana_page.statsButton.SetLabel("Show Statistics")
     # ------------------------------------------------------------------------------------------
     # ################
     # Stream page functions

--- a/magpy/gui/magpy_gui.py
+++ b/magpy/gui/magpy_gui.py
@@ -34,7 +34,7 @@ from magpy.gui.reportpage import *
 from magpy.gui.developpage import *  # remove this
 from magpy.gui.analysispage import *
 from magpy.gui.monitorpage import *
-from magpy.gui.statisticspage import StatisticsPanel
+from magpy.gui.statisticspage import StatisticsPage
 import glob, os, pickle, base64
 import pylab
 import thread, time
@@ -751,26 +751,30 @@ class MenuPanel(scrolled.ScrolledPanel):
     def __init__(self, *args, **kwds):
         scrolled.ScrolledPanel.__init__(self, *args, **kwds)
         # Create pages on MenuPanel
-        nb = wx.Notebook(self,-1)
-        self.str_page = StreamPage(nb)
-        self.flg_page = FlaggingPage(nb)
-        self.met_page = MetaPage(nb)
-        self.ana_page = AnalysisPage(nb)
-        self.abs_page = AbsolutePage(nb)
-        self.rep_page = ReportPage(nb)
-        self.com_page = MonitorPage(nb)
-        nb.AddPage(self.str_page, "Stream")
-        nb.AddPage(self.flg_page, "Flagging")
-        nb.AddPage(self.met_page, "Meta")
-        nb.AddPage(self.ana_page, "Analysis")
-        nb.AddPage(self.abs_page, "DI")
-        nb.AddPage(self.rep_page, "Report")
-        nb.AddPage(self.com_page, "Monitor")
+        self.nb = wx.Notebook(self,-1)
+        self.str_page = StreamPage(self.nb)
+        self.flg_page = FlaggingPage(self.nb)
+        self.met_page = MetaPage(self.nb)
+        self.ana_page = AnalysisPage(self.nb)
+        self.abs_page = AbsolutePage(self.nb)
+        self.rep_page = ReportPage(self.nb)
+        self.com_page = MonitorPage(self.nb)
+        self.stats_page = StatisticsPage(self.nb)
+        self.nb.AddPage(self.str_page, "Stream")
+        self.nb.AddPage(self.flg_page, "Flagging")
+        self.nb.AddPage(self.met_page, "Meta")
+        self.nb.AddPage(self.ana_page, "Analysis")
+        self.nb.AddPage(self.stats_page, "Statistics")
+        self.nb.AddPage(self.abs_page, "DI")
+        self.nb.AddPage(self.rep_page, "Report")
+        self.nb.AddPage(self.com_page, "Monitor")
 
         sizer = wx.BoxSizer()
-        sizer.Add(nb, 1, wx.EXPAND)
+        sizer.Add(self.nb, 1, wx.EXPAND)
         self.SetSizer(sizer)
         self.SetupScrolling()
+        self.nb.RemovePage(4)
+        self.stats_page.Hide()
 
 
 class MainFrame(wx.Frame):
@@ -779,13 +783,9 @@ class MainFrame(wx.Frame):
         wx.Frame.__init__(self, *args, **kwds)
         # The Splitted Window
         self.sp = wx.SplitterWindow(self, -1, style=wx.SP_3D|wx.SP_BORDER)
-        self.sp2 = wx.SplitterWindow(self.sp, -1, style=wx.SP_3D|wx.SP_BORDER)
-        self.plot_p = PlotPanel(self.sp2,-1)
-        self.menu_p = MenuPanel(self.sp2,-1)
-        self.sp2.SplitVertically(self.plot_p, self.menu_p, 800)
-        self.stats_p = StatisticsPanel(self.sp)
-        self.sp.SplitHorizontally(self.sp2, self.stats_p, 800)
-        self.sp.Unsplit(self.stats_p)
+        self.plot_p = PlotPanel(self.sp,-1)
+        self.menu_p = MenuPanel(self.sp,-1)
+        self.sp.SplitVertically(self.plot_p, self.menu_p, 800)
         pub.subscribe(self.changeStatusbar, 'changeStatusbar')
 
         # The Status Bar
@@ -1050,7 +1050,6 @@ class MainFrame(wx.Frame):
             self.StatusBar.SetStatusText(StatusBar_fields[i], i)
         self.menu_p.SetMinSize((400, 750))
         self.plot_p.SetMinSize((100, 100))
-        self.stats_p.SetMinSize((100, 100))
 
     def InitPlotParameter(self, keylist = None):
         # Kwargs for plotting
@@ -2379,11 +2378,15 @@ Suite 330, Boston, MA  02111-1307  USA"""
         self.SetStatusText(msg)
 
     def updateStatistics(self, event=None):
+        """
+        DESCRIPTION
+             Updates and sets the statistics if the statistics page
+             is displayed
+        """
         if self.menu_p.ana_page.statsButton.GetLabel() == 'Hide Statistics':
-            self.stats_p.stats_page.setStatistics(keys=self.shownkeylist,
+            self.menu_p.stats_page.setStatistics(keys=self.shownkeylist,
                     stream=self.plotstream.copy(),
                     xlimits=self.plot_p.xlimits)
-
 
     def UpdateCursorStatus(self, event):
         """Motion event for displaying values under cursor."""
@@ -4155,15 +4158,34 @@ Suite 330, Boston, MA  02111-1307  USA"""
         mp.plotSpectrogram(self.plotstream, comp)
 
     def onStatsButton(self, event):
+        """
+        DESCRIPTION
+             Creates/Destroys the statistics page int menu panel notebook
+             and sets the statistics
+        """
         status = self.menu_p.ana_page.statsButton.GetLabel()
         if status == 'Show Statistics':
-            self.sp.SplitHorizontally(self.sp2, self.stats_p, 800)
-            self.stats_p.stats_page.setStatistics(keys=self.shownkeylist,
+            # Remove last pages
+            self.menu_p.nb.RemovePage(4)
+            self.menu_p.abs_page.Hide()
+            self.menu_p.nb.RemovePage(4)
+            self.menu_p.rep_page.Hide()
+            self.menu_p.nb.RemovePage(4)
+            self.menu_p.com_page.Hide()
+            # Add new page next to the Analysis page
+            self.menu_p.nb.AddPage(self.menu_p.stats_page, "Statistics",
+                    True)
+            # Add back the last pages
+            self.menu_p.nb.AddPage(self.menu_p.abs_page, "DI")
+            self.menu_p.nb.AddPage(self.menu_p.rep_page, "Report")
+            self.menu_p.nb.AddPage(self.menu_p.com_page, "Monitor")
+            self.menu_p.stats_page.setStatistics(keys=self.shownkeylist,
                     stream=self.plotstream.copy(),
                     xlimits=self.plot_p.xlimits)
             self.menu_p.ana_page.statsButton.SetLabel("Hide Statistics")
         if status == 'Hide Statistics':
-            self.sp.Unsplit(self.stats_p)
+            self.menu_p.nb.RemovePage(4)
+            self.menu_p.stats_page.Hide()
             self.menu_p.ana_page.statsButton.SetLabel("Show Statistics")
     # ------------------------------------------------------------------------------------------
     # ################

--- a/magpy/gui/magpy_gui.py
+++ b/magpy/gui/magpy_gui.py
@@ -1632,7 +1632,6 @@ class MainFrame(wx.Frame):
             read stream, extract columns with values and display up to three of them by default
             executes guiPlot then
         """
-
         self.changeStatusbar("Plotting...")
 
         self.InitPlotParameter()
@@ -1664,6 +1663,10 @@ class MainFrame(wx.Frame):
                     checkbox.SetLabel(colname)
             else:
                 checkbox.SetValue(False)
+        for idx, ax in enumerate(self.plot_p.axlist):
+            ax.callbacks.connect('xlim_changed', self.updateStatistics)
+            ax.callbacks.connect('ylim_changed', self.updateStatistics)
+        self.updateStatistics()
         self.changeStatusbar("Ready")
 
 
@@ -1703,6 +1706,7 @@ class MainFrame(wx.Frame):
                     checkbox.SetLabel(colname)
             else:
                 checkbox.SetValue(False)
+        self.updateStatistics()
         self.changeStatusbar("Ready")
 
 
@@ -2362,6 +2366,12 @@ Suite 330, Boston, MA  02111-1307  USA"""
 
     def changeStatusbar(self,msg):
         self.SetStatusText(msg)
+
+    def updateStatistics(self, event=None):
+        self.menu_p.ana_page.setStatistics(keys=self.shownkeylist,
+                stream=self.plotstream.copy(),
+                xlimits=self.plot_p.xlimits)
+
 
     def UpdateCursorStatus(self, event):
         """Motion event for displaying values under cursor."""

--- a/magpy/gui/statisticspage.py
+++ b/magpy/gui/statisticspage.py
@@ -4,24 +4,6 @@ import wx
 import wx.lib.scrolledpanel as scrolled
 
 
-class StatisticsPanel(scrolled.ScrolledPanel):
-    """
-    DESCRIPTION
-        Scrolled Panel that contains all methods for the lower statistics.
-        panel and its insets
-    """
-    def __init__(self, *args, **kwds):
-        scrolled.ScrolledPanel.__init__(self, *args, **kwds)
-        # Create pages on MenuPanel
-        nb = wx.Notebook(self,-1)
-        self.stats_page = StatisticsPage(nb)
-        nb.AddPage(self.stats_page, "Continuous Statistics")
-        sizer = wx.BoxSizer()
-        sizer.Add(nb, 1, wx.EXPAND)
-        self.SetSizer(sizer)
-        self.SetupScrolling()
-
-
 class StatisticsPage(wx.Panel):
     """
     DESCRIPTION
@@ -33,30 +15,45 @@ class StatisticsPage(wx.Panel):
         self.doLayout()
 
     def createControls(self):
-        self.statisticsLabel = wx.StaticText(self, label="Statistics:")
-        self.timeLabel = wx.StaticText(self, label="")
-        self.statisticsTextCtrl = wx.TextCtrl(self, wx.ID_ANY,
-                style=wx.TE_MULTILINE|wx.TE_READONLY|wx.HSCROLL|wx.VSCROLL)
-        self.valuesLabel = wx.StaticText(self,
-                label="Individual Values (For ten or less data points):")
-        self.valuesTextCtrl = wx.TextCtrl(self, wx.ID_ANY,
-                style=wx.TE_MULTILINE|wx.TE_READONLY|wx.HSCROLL|wx.VSCROLL)
+        self.timeLabel = wx.StaticText(self, -1, label="", size=(330,20))
+        self.compLabel0 = wx.StaticText(self, -1, label="", size=(330,20))
+        self.compLabel1 = wx.StaticText(self, -1, label="", size=(330,20))
+        self.compLabel2 = wx.StaticText(self, -1, label="", size=(330,20))
+        self.compLabel3 = wx.StaticText(self, -1, label="", size=(330,20))
+        self.compLabel4 = wx.StaticText(self, -1, label="", size=(330,20))
+        self.compLabel5 = wx.StaticText(self, -1, label="", size=(330,20))
+        self.compStats0 = wx.StaticText(self, -1, label="", size=(375,90))
+        self.compStats1 = wx.StaticText(self, -1, label="", size=(375,90))
+        self.compStats2 = wx.StaticText(self, -1, label="", size=(375,90))
+        self.compStats3 = wx.StaticText(self, -1, label="", size=(375,90))
+        self.compStats4 = wx.StaticText(self, -1, label="", size=(375,90))
+        self.compStats5 = wx.StaticText(self, -1, label="", size=(375,90))
+
 
     def doLayout(self):
-      mainSizer = wx.BoxSizer(wx.HORIZONTAL)
-      gridSizer = wx.FlexGridSizer(3, 2, 5,10)
-      gridSizer.AddMany([(self.timeLabel),
-            (0, 0),
-            (self.statisticsLabel),
-            (self.valuesLabel),
-            (self.statisticsTextCtrl, 1, wx.EXPAND),
-            (self.valuesTextCtrl, 1, wx.EXPAND)])
-      gridSizer.AddGrowableRow(2, 1)
-      gridSizer.AddGrowableCol(1, 1)
-      gridSizer.AddGrowableCol(0, 1)
-      mainSizer.Add(gridSizer, proportion = 2,
-            flag = wx.ALIGN_LEFT | wx.ALL |wx.EXPAND, border=5)
-      self.SetSizer(mainSizer)
+      boxSizer = wx.BoxSizer(orient=wx.HORIZONTAL)
+      elemlist = [(self.timeLabel, dict()),
+            (self.compLabel0, dict()),
+            (self.compStats0, dict()),
+            (self.compLabel1, dict()),
+            (self.compStats1, dict()),
+            (self.compLabel2, dict()),
+            (self.compStats2, dict()),
+            (self.compLabel3, dict()),
+            (self.compStats3, dict()),
+            (self.compLabel4, dict()),
+            (self.compStats4, dict()),
+            (self.compLabel5, dict()),
+            (self.compStats5, dict())]
+      cols = 1
+      rows = int(np.ceil(len(elemlist)/float(cols)))
+      gridSizer = wx.FlexGridSizer(rows=rows, cols=cols, vgap=5, hgap=5)
+      for control, options in elemlist:
+          gridSizer.Add(control, **options)
+      for control, options in \
+              [(gridSizer, dict(border=5, flag=wx.ALL))]:
+          boxSizer.Add(control, **options)
+      self.SetSizerAndFit(boxSizer)
 
     def getDataPoints(self, keys, teststream):
         """
@@ -90,10 +87,10 @@ class StatisticsPage(wx.Panel):
         """
         try:
             mini = teststream._get_min(key,returntime=True)
-            minText = '       Minimum: {} at {}\n'.format(mini[0],
+            minText = '   Min : {} at {}\n'.format(mini[0],
                     num2date(mini[1]))
         except:
-            minText = '       Unable to calculate minimum.\n'
+            minText = '   Unable to calculate minimum.\n'
         return minText
 
     def getMax(self, key, teststream):
@@ -108,10 +105,10 @@ class StatisticsPage(wx.Panel):
         """
         try:
             maxi = teststream._get_max(key,returntime=True)
-            maxText = '       Maximum: {} at {}\n'.format(maxi[0],
+            maxText = '   Max : {} at {}\n'.format(maxi[0],
                     num2date(maxi[1]))
         except:
-            maxText = '       Unable to calculate maximum.\n'
+            maxText = '   Unable to calculate maximum.\n'
         return maxText
 
     def getMean(self, key, teststream):
@@ -127,14 +124,14 @@ class StatisticsPage(wx.Panel):
         try:
             mean = teststream.mean(key, meanfunction='mean',
                     std=True,percentage=10)
-            line = '       Mean: {}\n'.format(mean[0])
-            line += '       Standard Deviation: {}\n'.format(mean[1])
+            line = '   Mean : {}\n'.format(mean[0])
+            line += u'   \u03C3 : {0:.2f}\n'.format(mean[1])
             meanText = line
         except:
-            meanText = '       Unable to calculate mean.\n'
+            meanText = '   Unable to calculate mean.\n'
         return meanText
 
-    def getStatistics(self, keys, teststream):
+    def getStatistics(self, key, teststream):
         """
         DESCRIPTION:
             Function to format statistics.
@@ -144,16 +141,12 @@ class StatisticsPage(wx.Panel):
         RETURNS:
             A string displaying statistics of a time series
         """
-        statisticText = ''
-        for key in keys:
-            header = '|------------------------------{}'.format(key) + \
-                    '------------------------------|\n'
-            minText = self.getMin(key, teststream)
-            maxText = self.getMax(key, teststream)
-            meanText = self.getMean(key, teststream)
-            varText = self.getVariance(key, teststream)
-            statisticText += header + minText + maxText + meanText + \
-                    varText
+        minText = self.getMin(key, teststream)
+        maxText = self.getMax(key, teststream)
+        meanText = self.getMean(key, teststream)
+        varText = self.getVariance(key, teststream)
+        statisticText = minText + maxText + meanText + \
+                varText
         return statisticText
 
     def getVariance(self, key, teststream):
@@ -168,9 +161,9 @@ class StatisticsPage(wx.Panel):
         """
         try:
             var = teststream._get_variance(key)
-            varText = '       Variance: {}\n'.format(var)
+            varText = u'   \u03C3\u00B2 : {0:.2f}'.format(var)
         except:
-            varText = '       Unable to calculate variance.\n'
+            varText = '   Unable to calculate variance.'
         return varText
 
     def setStatistics(self, keys, stream, xlimits):
@@ -185,22 +178,26 @@ class StatisticsPage(wx.Panel):
         RETURNS:
             A string displaying the variance value of a time series
         """
+
+        titleFont = wx.Font(12, wx.DEFAULT, wx.NORMAL, wx.BOLD)
+        for idx in range(6):
+            exec('self.compLabel'+str(idx)+'.SetLabel(" ")')
+            exec('self.compStats'+str(idx)+'.SetLabel(" ")')
+        self.timeLabel.SetFont(titleFont)
         try:
             testarray = stream._select_timerange(starttime=xlimits[0],
                     endtime=xlimits[1])
             teststream = DataStream([LineStruct()], stream, testarray)
             t_limits = teststream._find_t_limits()
-            trange = 'Timerange: {} to {}'.format(t_limits[0],
+            trange = '{} to {}\n'.format(t_limits[0],
                     t_limits[1])
             self.timeLabel.SetLabel(trange)
-            stats = self.getStatistics(keys, teststream)
-            self.statisticsTextCtrl.SetValue(stats)
-            if len(teststream.ndarray[KEYLIST.index('time')]) <= 10:
-                dataPoints = self.getDataPoints(keys, teststream)
-                self.valuesTextCtrl.SetValue(dataPoints)
-            else:
-                self.valuesTextCtrl.SetValue('Too many data points...')
+            for idx, key in enumerate(keys):
+                stats = self.getStatistics(key, teststream)
+                title = key.upper() + ' Component: '
+                exec('self.compLabel'+str(idx)+'.SetLabel(title)')
+                exec('self.compLabel'+str(idx)+'.SetFont(titleFont)')
+                exec('self.compStats'+str(idx)+'.SetLabel(stats)')
         except:
-            message = 'Cannot get statistics for time range.'
-            self.statisticsTextCtrl.SetValue(message)
-            self.valuesTextCtrl.SetValue(message)
+            message = 'No statistics for this time range.'
+            self.timeLabel.SetLabel(message)

--- a/magpy/gui/statisticspage.py
+++ b/magpy/gui/statisticspage.py
@@ -1,0 +1,206 @@
+from magpy.stream import *
+
+import wx
+import wx.lib.scrolledpanel as scrolled
+
+
+class StatisticsPanel(scrolled.ScrolledPanel):
+    """
+    DESCRIPTION
+        Scrolled Panel that contains all methods for the lower statistics.
+        panel and its insets
+    """
+    def __init__(self, *args, **kwds):
+        scrolled.ScrolledPanel.__init__(self, *args, **kwds)
+        # Create pages on MenuPanel
+        nb = wx.Notebook(self,-1)
+        self.stats_page = StatisticsPage(nb)
+        nb.AddPage(self.stats_page, "Continuous Statistics")
+        sizer = wx.BoxSizer()
+        sizer.Add(nb, 1, wx.EXPAND)
+        self.SetSizer(sizer)
+        self.SetupScrolling()
+
+
+class StatisticsPage(wx.Panel):
+    """
+    DESCRIPTION
+        Panel that contains methods for displaying continuous statistics.
+    """
+    def __init__(self, *args, **kwds):
+        wx.Panel.__init__(self, *args, **kwds)
+        self.createControls()
+        self.doLayout()
+
+    def createControls(self):
+        self.statisticsLabel = wx.StaticText(self, label="Statistics:")
+        self.timeLabel = wx.StaticText(self, label="")
+        self.statisticsTextCtrl = wx.TextCtrl(self, wx.ID_ANY,
+                style=wx.TE_MULTILINE|wx.TE_READONLY|wx.HSCROLL|wx.VSCROLL)
+        self.valuesLabel = wx.StaticText(self,
+                label="Individual Values (For ten or less data points):")
+        self.valuesTextCtrl = wx.TextCtrl(self, wx.ID_ANY,
+                style=wx.TE_MULTILINE|wx.TE_READONLY|wx.HSCROLL|wx.VSCROLL)
+
+    def doLayout(self):
+      mainSizer = wx.BoxSizer(wx.HORIZONTAL)
+      gridSizer = wx.FlexGridSizer(3, 2, 5,10)
+      gridSizer.AddMany([(self.timeLabel),
+            (0, 0),
+            (self.statisticsLabel),
+            (self.valuesLabel),
+            (self.statisticsTextCtrl, 1, wx.EXPAND),
+            (self.valuesTextCtrl, 1, wx.EXPAND)])
+      gridSizer.AddGrowableRow(2, 1)
+      gridSizer.AddGrowableCol(1, 1)
+      gridSizer.AddGrowableCol(0, 1)
+      mainSizer.Add(gridSizer, proportion = 2,
+            flag = wx.ALIGN_LEFT | wx.ALL |wx.EXPAND, border=5)
+      self.SetSizer(mainSizer)
+
+    def getDataPoints(self, keys, teststream):
+        """
+        DESCRIPTION:
+            Function to display values of a time series.
+        PARAMETERS:
+            keys            (list) list of key(s)
+            teststream      (DataStream object) stream containing data
+        RETURNS:
+            A string displaying the values in a time series
+        """
+        valueText = ''
+        times = teststream.ndarray[KEYLIST.index('time')]
+        for key in keys:
+            valueText += '|-----------------------{}'.format(key) + \
+                    '-----------------------|\n'.format(key)
+            for t, val in zip(times, teststream.ndarray[KEYLIST.index(key)]):
+                line = '     {}: {}\n'.format(num2date(t), val)
+                valueText += line
+        return valueText
+
+    def getMin(self, key, teststream):
+        """
+        DESCRIPTION:
+            Function to display minimum value of a time series.
+        PARAMETERS:
+            keys            (list) list of key(s)
+            teststream      (DataStream object) stream containing data
+        RETURNS:
+            A string displaying the minimum value in a time series
+        """
+        try:
+            mini = teststream._get_min(key,returntime=True)
+            minText = '       Minimum: {} at {}\n'.format(mini[0],
+                    num2date(mini[1]))
+        except:
+            minText = '       Unable to calculate minimum.\n'
+        return minText
+
+    def getMax(self, key, teststream):
+        """
+        DESCRIPTION:
+            Function to display maximum value of a time series.
+        PARAMETERS:
+            keys            (list) list of key(s)
+            teststream      (DataStream object) stream containing data
+        RETURNS:
+            A string displaying the maximum value in a time series
+        """
+        try:
+            maxi = teststream._get_max(key,returntime=True)
+            maxText = '       Maximum: {} at {}\n'.format(maxi[0],
+                    num2date(maxi[1]))
+        except:
+            maxText = '       Unable to calculate maximum.\n'
+        return maxText
+
+    def getMean(self, key, teststream):
+        """
+        DESCRIPTION:
+            Function to display mean value of a time series.
+        PARAMETERS:
+            keys            (list) list of key(s)
+            teststream      (DataStream object) stream containing data
+        RETURNS:
+            A string displaying the mean value of a time series
+        """
+        try:
+            mean = teststream.mean(key, meanfunction='mean',
+                    std=True,percentage=10)
+            line = '       Mean: {}\n'.format(mean[0])
+            line += '       Standard Deviation: {}\n'.format(mean[1])
+            meanText = line
+        except:
+            meanText = '       Unable to calculate mean.\n'
+        return meanText
+
+    def getStatistics(self, keys, teststream):
+        """
+        DESCRIPTION:
+            Function to format statistics.
+        PARAMETERS:
+            keys            (list) list of key(s)
+            teststream      (DataStream object) stream containing data
+        RETURNS:
+            A string displaying statistics of a time series
+        """
+        statisticText = ''
+        for key in keys:
+            header = '|------------------------------{}'.format(key) + \
+                    '------------------------------|\n'
+            minText = self.getMin(key, teststream)
+            maxText = self.getMax(key, teststream)
+            meanText = self.getMean(key, teststream)
+            varText = self.getVariance(key, teststream)
+            statisticText += header + minText + maxText + meanText + \
+                    varText
+        return statisticText
+
+    def getVariance(self, key, teststream):
+        """
+        DESCRIPTION:
+            Function to display variance value of a time series.
+        PARAMETERS:
+            keys            (list) list of key(s)
+            teststream      (DataStream object) stream containing data
+        RETURNS:
+            A string displaying the variance value of a time series
+        """
+        try:
+            var = teststream._get_variance(key)
+            varText = '       Variance: {}\n'.format(var)
+        except:
+            varText = '       Unable to calculate variance.\n'
+        return varText
+
+    def setStatistics(self, keys, stream, xlimits):
+        """
+        DESCRIPTION:
+            Function to set and display statistics and values in text
+            controls.
+        PARAMETERS:
+            keys            (list) list of key(s)
+            stream          (DataStream object) stream containing data
+            xlimits         (list) list with limits of a time series
+        RETURNS:
+            A string displaying the variance value of a time series
+        """
+        try:
+            testarray = stream._select_timerange(starttime=xlimits[0],
+                    endtime=xlimits[1])
+            teststream = DataStream([LineStruct()], stream, testarray)
+            t_limits = teststream._find_t_limits()
+            trange = 'Timerange: {} to {}'.format(t_limits[0],
+                    t_limits[1])
+            self.timeLabel.SetLabel(trange)
+            stats = self.getStatistics(keys, teststream)
+            self.statisticsTextCtrl.SetValue(stats)
+            if len(teststream.ndarray[KEYLIST.index('time')]) <= 10:
+                dataPoints = self.getDataPoints(keys, teststream)
+                self.valuesTextCtrl.SetValue(dataPoints)
+            else:
+                self.valuesTextCtrl.SetValue('Too many data points...')
+        except:
+            message = 'Cannot get statistics for time range.'
+            self.statisticsTextCtrl.SetValue(message)
+            self.valuesTextCtrl.SetValue(message)

--- a/magpy/stream.py
+++ b/magpy/stream.py
@@ -1575,6 +1575,14 @@ CALLED BY:
         else:
             return result
 
+    def _get_variance(self, key):
+        if not key in KEYLIST[:16]:
+            raise ValueError("Column key not valid")
+        key_ind = KEYLIST.index(key)
+        if len(self.ndarray[0]) > 0:
+            result = np.var(self.ndarray[key_ind].astype(float))
+            return result
+
     def amplitude(self,key):
         """
         DESCRIPTION:
@@ -9284,22 +9292,22 @@ CALLED BY:
         format_type='IAGA'
         ------------------
            *General:
-            The meta information provided within the header of each IAGA file is automatically 
-            generated from the header information provided along with the following keys 
+            The meta information provided within the header of each IAGA file is automatically
+            generated from the header information provided along with the following keys
             (define by stream.header[key]):
             - Obligatory: StationInstitution, StationName, StationIAGAcode (or StationID),
                         DataElevation, DataSensorOrientation, DataDigitalSampling
-            - Optional:   SensorID, DataPublicationDate, DataComments, DataConversion, StationK9, 
-                          SecondarySensorID (F sensor), StationMeans (used for 'Approx H') 
+            - Optional:   SensorID, DataPublicationDate, DataComments, DataConversion, StationK9,
+                          SecondarySensorID (F sensor), StationMeans (used for 'Approx H')
             - Header input "IntervalType": can either be provided by using key 'DataIntervalType'
                           or is automatically created from DataSamplingRate.
-                          Filter details as contained in DataSamplingFilter are added to the 
+                          Filter details as contained in DataSamplingFilter are added to the
                           commentary part
             - Header input "Geodetic Longitude and Latitude":
                           - defined with keys 'DataAcquisitionLatitude','DataAcquisitionLongitude'
                           - if an EPSG code is provided in key 'DataLocationReference'
                             this code is used to convert Lat and Long into the WGS84 system
-                            e.g. stream.header['DataLocationReference'] = 'M34, EPSG: ' 
+                            e.g. stream.header['DataLocationReference'] = 'M34, EPSG: '
 
            *Specific parameters:
             - useg          (Bool) if F is available, and G not yet caluclated: calculate G (deltaF) and
@@ -9324,7 +9332,7 @@ CALLED BY:
 
            *Specific parameters:
             - addflags      (BOOL) add flags to IMAGCDF output if True
-                    
+
         format_type='BLV'
         ------------------
            *Specific parameters:
@@ -12519,7 +12527,7 @@ def test_time(time):
 def LeapTime(t):
     """
     converts strings to datetime, considering leap seconds
-    """ 
+    """
     nofrag, frag = t.split('.')
     nofrag_dt = time.strptime(nofrag, "%Y-%m-%dT%H:%M:%S")
     ts = datetime.fromtimestamp(time.mktime(nofrag_dt))

--- a/magpy/stream.py
+++ b/magpy/stream.py
@@ -1580,7 +1580,7 @@ CALLED BY:
             raise ValueError("Column key not valid")
         key_ind = KEYLIST.index(key)
         if len(self.ndarray[0]) > 0:
-            result = np.var(self.ndarray[key_ind].astype(float))
+            result = np.nanvar(self.ndarray[key_ind].astype(float))
             return result
 
     def amplitude(self,key):


### PR DESCRIPTION
Potential way to display statistics continuously, as discussed in the demo meeting. This includes the calculation of variance. The panel updates continuously as the data is manipulated, including the use of the navigation toolbar, trim method, and flagging methods.