### PR TITLE
Generalize methods to make them less USGS specific

### DIFF
--- a/magpy/absolutes.py
+++ b/magpy/absolutes.py
@@ -1497,6 +1497,7 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
         - expT:         (float) expected value threshold - default 1 deg
         - movetoarchive:(string) define a local directory to store archived data (only works when reading files)
         - datastream:   ((DataStream object) provides vario and scalar data as an alternative to reading files
+        - jsonformat: (bool) if true data is in JSONABS format
     RETURNS:
         --
     EXAMPLE:
@@ -1550,6 +1551,7 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
     meantime = kwargs.get('meantime')
     movetoarchive = kwargs.get('movetoarchive')
     datastream = kwargs.get('datastream')
+    jsonformat = kwargs.get('jsonformat')
 
     if not outputformat:
         outputformat='idf'
@@ -1624,7 +1626,7 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
             #filelist.append(absdata)
             if "://" in absdata:
                 print("Found URL code - requires name of data set with date")
-                if "observation.json" in absdata:
+                if jsonformat == True:
                     dataformat = 'JSONABS'
                 filelist.append(absdata)
                 movetoarchive = False # XXX No archiving function supported so far - will be done as soon as writing to files is available
@@ -1646,7 +1648,7 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
                 listlen = len(absdata)
                 for elem in absdata:
                     if "://" in elem:
-                        if "observation.json" in elem:
+                        if jsonformat == True:
                             dataformat = 'JSONABS'
                         print("Found URL code - requires name of data set with date")
                         filelist.append(elem)
@@ -1711,7 +1713,7 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
                 tempstream = read(url)
                 datastream = joinStreams(tempstream,datastream)
             except:
-                print('Unable to load USGS scalar and vario data from: ' + url)
+                print('Unable to load scalar and vario data from: ' + url)
         if endtime > streamend and endtime-streamend > timedelta(seconds=deltat):
             parsed = url.split('&')
             parsed = [el for el in parsed if not "starttime=" in el and not "endtime=" in el]
@@ -1722,7 +1724,7 @@ def absoluteAnalysis(absdata, variodata, scalardata, **kwargs):
                 tempstream = read(url)
                 datastream = joinStreams(datastream,tempstream)
             except:
-                print('Unable to load USGS scalar and vario data from: ' + url)
+                print('Unable to load scalar and vario data from: ' + url)
         streamstart=datastream.ndarray[KEYLIST.index('time')][0]
         streamend=datastream.ndarray[KEYLIST.index('time')][-1]
         streamstart = num2date(streamstart).replace(tzinfo=None)

--- a/magpy/gui/absolutespage.py
+++ b/magpy/gui/absolutespage.py
@@ -33,7 +33,7 @@ class AbsolutePage(wx.Panel):
     def createControls(self):
         self.diLabel = wx.StaticText(self, label="DI files:")
         self.loadDIButton = wx.Button(self,-1,"Load DI data",size=(160,30))
-        self.loadUSGSButton = wx.Button(self,-1,"Load USGS data",size=(160,30))
+        self.loadWebserviceButton = wx.Button(self,-1,"Load Baselines",size=(160,30))
         self.diTextCtrl = wx.TextCtrl(self, value="None",size=(160,40),
                           style = wx.TE_MULTILINE|wx.TE_READONLY|wx.HSCROLL|wx.VSCROLL)
         self.defineVarioButton = wx.Button(self,-1,"Variometer path",size=(160,30))
@@ -87,7 +87,7 @@ class AbsolutePage(wx.Panel):
                  (self.varioTextCtrl, expandOption),
                  (self.defineScalarButton, dict(flag=wx.ALIGN_CENTER)),
                  (self.scalarTextCtrl, expandOption),
-                 (self.loadUSGSButton,dict(flag=wx.ALIGN_CENTER)),
+                 (self.loadWebserviceButton,dict(flag=wx.ALIGN_CENTER)),
                   emptySpace,
                   emptySpace,
                   emptySpace,

--- a/magpy/gui/dialogclasses.py
+++ b/magpy/gui/dialogclasses.py
@@ -117,29 +117,30 @@ class ConnectWebServiceDialog(wx.Dialog):
     Helper method to generate urls and connect to a WebService
     Select shown keys
     """
-    def __init__(self, parent, title, ids, types, formats):
+    def __init__(self, parent, title, ids, types, formats, base):
         super(ConnectWebServiceDialog, self).__init__(parent=parent,
             title=title, size=(400, 600))
         self.ids = ids
         self.types = types
         self.formats = formats
+        self.base = base
         self.createControls()
         self.doLayout()
         self.bindControls()
         self.createUrl()
 
     def createControls(self):
-        base = 'https://geomag.usgs.gov/ws/edge/?'
-        self.baseLabel = wx.StaticText(self, label='Base URL:',size=(400,20))
-        self.baseTextCtrl = wx.TextCtrl(self, value=base,size=(400,25))
+        self.baseLabel = wx.StaticText(self, label='Base URL:', size=(400,20))
+        self.baseTextCtrl = wx.TextCtrl(self, value=self.base, size=(400,25))
         self.obsIDLabel = wx.StaticText(self,
                 label="Observatory ID:", size=(400,20))
         self.idComboBox = wx.ComboBox(self, choices=self.ids,
-            style=wx.CB_DROPDOWN,size=(400,25))
-        self.formatLabel = wx.StaticText(self, label="Format: ",size=(400,20))
+            style=wx.CB_DROPDOWN, size=(400,25))
+        self.formatLabel = wx.StaticText(self, label="Format: ",
+                size=(400,20))
         self.formatComboBox = wx.ComboBox(self, choices=self.formats,
-            style=wx.CB_DROPDOWN,size=(400,25))
-        self.typeLabel = wx.StaticText(self, label="Type: ",size=(400,20))
+            style=wx.CB_DROPDOWN, size=(400,25))
+        self.typeLabel = wx.StaticText(self, label="Type: ", size=(400,20))
         self.typeComboBox = wx.ComboBox(self, choices=self.types,
             style=wx.CB_DROPDOWN, size=(400,25))
         self.sampleLabel = wx.StaticText(self,
@@ -161,7 +162,7 @@ class ConnectWebServiceDialog(wx.Dialog):
                 label="Comma separated list of requested elements: ",
                 size=(400,20))
         self.elementsTextCtrl = wx.TextCtrl(self,
-                value='X,Y,Z,F',size=(400,25))
+                value='X,Y,Z,F', size=(400,25))
         self.generatedLabel = wx.StaticText(self, label="Generated URL:",
                 size=(400,20))
         self.generatedTextCtrl = wx.TextCtrl(self, value='', size=(400,25))
@@ -169,7 +170,7 @@ class ConnectWebServiceDialog(wx.Dialog):
                 label="Sample Limit (0 if no limit. 345600 for USGS default.): ",
                 size=(400,25))
         self.sampleLimitTextCtrl = wx.TextCtrl(self,
-                value='345600',size=(400,25))
+                value='345600', size=(400,25))
         self.okButton = wx.Button(self, wx.ID_OK, label='OK', size=(400,25))
         self.closeButton = wx.Button(self, wx.ID_CANCEL, label='Cancel',
                 size=(400,25))
@@ -768,41 +769,71 @@ class OptionsInitDialog(wx.Dialog):
 
     # Widgets
     def createControls(self):
-        # single anaylsis
-        # db = mysql.connect (host = "localhost",user = "user",passwd = "secret",db = "mysqldb")
-        self.dboptLabel = wx.StaticText(self, label="Database:",size=(160,30))
-        self.basicLabel = wx.StaticText(self, label="Basics:",size=(160,30))
-        self.calcLabel = wx.StaticText(self, label="Calculation:",size=(160,30))
-        self.hostLabel = wx.StaticText(self, label="Host",size=(160,30))
-        self.hostTextCtrl = wx.TextCtrl(self,value=self.options.get('host','localhost'),size=(160,30))
-        self.userLabel = wx.StaticText(self, label="User",size=(160,30))
-        self.userTextCtrl = wx.TextCtrl(self, value=self.options.get('user','Max'),size=(160,30))
-        self.passwdLabel = wx.StaticText(self, label="Password",size=(160,30))
-        self.passwdTextCtrl = wx.TextCtrl(self, value=self.options.get('passwd','Secret'),style=wx.TE_PASSWORD,size=(160,30))
-        self.dbLabel = wx.StaticText(self, label="Database",size=(160,30))
-        self.dbTextCtrl = wx.TextCtrl(self, value=self.options.get('dbname','MyDB'),size=(160,30))
-        self.dirnameLabel = wx.StaticText(self, label="Default directory",size=(160,30))
-        self.dirnameTextCtrl = wx.TextCtrl(self, value=self.options.get('dirname',''),size=(160,30))
-
-        self.stationidLabel = wx.StaticText(self, label="Station ID",size=(160,30))
-        self.stationidTextCtrl = wx.TextCtrl(self, value=self.options.get('stationid','WIC'),size=(160,30))
-
-        self.fitfunctionLabel = wx.StaticText(self, label="Fit function",size=(160,30))
+        webservice = self.options.get('intermagnetbase',
+                'https://geomag.usgs.gov/ws/edge/?')
+        baselines = self.options.get('baselinebase',
+                'https://geomag.usgs.gov/baselines/observation.json.php?')
+        self.dboptLabel = wx.StaticText(self, label="Database:",
+                size=(160, 30))
+        self.basicLabel = wx.StaticText(self, label="Basics:", size=(160, 30))
+        self.calcLabel = wx.StaticText(self, label="Calculation:",
+                size=(160, 30))
+        self.hostLabel = wx.StaticText(self, label="Host", size=(160, 30))
+        self.hostTextCtrl = wx.TextCtrl(self,
+                value=self.options.get('host', 'localhost'), size=(160, 30))
+        self.userLabel = wx.StaticText(self, label="User", size=(160, 30))
+        self.userTextCtrl = wx.TextCtrl(self,
+                value=self.options.get('user', 'Max'), size=(160, 30))
+        self.passwdLabel = wx.StaticText(self, label="Password",
+                size=(160, 30))
+        self.passwdTextCtrl = wx.TextCtrl(self,
+                value=self.options.get('passwd', 'Secret'),
+                style=wx.TE_PASSWORD,size=(160, 30))
+        self.dbLabel = wx.StaticText(self, label="Database", size=(160, 30))
+        self.dbTextCtrl = wx.TextCtrl(self,
+                value=self.options.get('dbname', 'MyDB'), size=(160, 30))
+        self.dirnameLabel = wx.StaticText(self, label="Default directory",
+                size=(160, 30))
+        self.dirnameTextCtrl = wx.TextCtrl(self,
+                value=self.options.get('dirname', ''), size=(160, 30))
+        self.webserviceURLLabel = wx.StaticText(self,
+                label="Default intermagnet webservice baselines URL",
+                size=(160, 35))
+        self.webserviceURLTextCtrl = wx.TextCtrl(self, value=webservice,
+                size=(160, 30))
+        self.webserviceBaselinesLabel = wx.StaticText(self,
+                label="Default baseline webservice base URL", size=(160, 35))
+        self.webserviceBaselinesTextCtrl = wx.TextCtrl(self,
+                value=self.options.get('baselinebase',''), size=(160, 30))
+        self.stationidLabel = wx.StaticText(self, label="Station ID",
+                size=(160, 30))
+        self.stationidTextCtrl = wx.TextCtrl(self,
+                value=self.options.get('stationid', 'WIC'), size=(160, 30))
+        self.fitfunctionLabel = wx.StaticText(self, label="Fit function",
+                size=(160, 30))
         self.fitfunctionComboBox = wx.ComboBox(self, choices=self.funclist,
-                              style=wx.CB_DROPDOWN, value=self.options.get('fitfunction','spline'),size=(160,-1))
-        self.fitknotstepLabel = wx.StaticText(self, label="Knotstep (spline)",size=(160,30))
-        self.fitknotstepTextCtrl = wx.TextCtrl(self, value=self.options.get('fitknotstep','0.3'),size=(160,30))
-        self.fitdegreeLabel = wx.StaticText(self, label="Degree (polynom)",size=(160,30))
-        self.fitdegreeTextCtrl = wx.TextCtrl(self, value=self.options.get('fitdegree','5'),size=(160,30))
-        self.bookmarksLabel = wx.StaticText(self, label="Favorite URLs",size=(160,30))
-        bm = self.options.get('bookmarks',['http://www.intermagnet.org/test/ws/?id=BOU'])
-        self.bookmarksComboBox = wx.ComboBox(self, choices=bm,style=wx.CB_DROPDOWN, value=bm[0],size=(160,-1))
-
-        self.closeButton = wx.Button(self, wx.ID_CANCEL, label='Cancel',size=(160,30))
-        self.saveButton = wx.Button(self, wx.ID_OK, label='Save',size=(160,30))
-
-        #self.bookmarksComboBox.Disable()
-
+                style=wx.CB_DROPDOWN,
+                value=self.options.get('fitfunction', 'spline'),
+                size=(160, -1))
+        self.fitknotstepLabel = wx.StaticText(self, label="Knotstep (spline)",
+                size=(160, 30))
+        self.fitknotstepTextCtrl = wx.TextCtrl(self,
+                value=self.options.get('fitknotstep', '0.3'),
+                size=(160, 30))
+        self.fitdegreeLabel = wx.StaticText(self, label="Degree (polynom)",
+                size=(160, 30))
+        self.fitdegreeTextCtrl = wx.TextCtrl(self,
+                value=self.options.get('fitdegree', '5'), size=(160, 30))
+        self.bookmarksLabel = wx.StaticText(self, label="Favorite URLs",
+                size=(160, 30))
+        bm = self.options.get('bookmarks',
+                ['http://www.intermagnet.org/test/ws/?id=BOU'])
+        self.bookmarksComboBox = wx.ComboBox(self, choices=bm,
+                style=wx.CB_DROPDOWN, value=bm[0], size=(160, -1))
+        self.closeButton = wx.Button(self, wx.ID_CANCEL, label='Cancel',
+                size=(160, 30))
+        self.saveButton = wx.Button(self, wx.ID_OK, label='Save',
+                size=(160, 30))
         f = self.dboptLabel.GetFont()
         newf = wx.Font(14, wx.DECORATIVE, wx.ITALIC, wx.BOLD)
         self.dboptLabel.SetFont(newf)
@@ -832,22 +863,29 @@ class OptionsInitDialog(wx.Dialog):
                  (self.passwdTextCtrl, expandOption),
                  (self.dbTextCtrl, expandOption),
                  (self.basicLabel, noOptions),
-                  emptySpace,
-                  emptySpace,
-                  emptySpace,
+                 emptySpace,
+                 emptySpace,
+                 emptySpace,
                  (self.dirnameLabel, noOptions),
+                 (self.webserviceURLLabel, noOptions),
+                 (self.webserviceBaselinesLabel, noOptions),
                  (self.stationidLabel, noOptions),
-                  emptySpace,
-                 (self.bookmarksLabel, noOptions),
                  (self.dirnameTextCtrl, expandOption),
+                 (self.webserviceURLTextCtrl, expandOption),
+                 (self.webserviceBaselinesTextCtrl, expandOption),
                  (self.stationidTextCtrl, expandOption),
-                  emptySpace,
+                 (self.bookmarksLabel, noOptions),
+                 emptySpace,
+                 emptySpace,
+                 emptySpace,
                  (self.bookmarksComboBox, noOptions),
+                 emptySpace,
+                 emptySpace,
+                 emptySpace,
                  (self.calcLabel, noOptions),
-                  emptySpace,
-                  emptySpace,
-                  emptySpace,
-                  emptySpace,
+                 emptySpace,
+                 emptySpace,
+                 emptySpace,
                  (self.fitfunctionLabel, noOptions),
                  (self.fitknotstepLabel, noOptions),
                  (self.fitdegreeLabel, noOptions),
@@ -855,9 +893,9 @@ class OptionsInitDialog(wx.Dialog):
                  (self.fitfunctionComboBox, noOptions),
                  (self.fitknotstepTextCtrl, expandOption),
                  (self.fitdegreeTextCtrl, expandOption),
+                 emptySpace,
+                 emptySpace,
                  (self.saveButton, dict(flag=wx.ALIGN_CENTER)),
-                  emptySpace,
-                  emptySpace,
                  (self.closeButton, dict(flag=wx.ALIGN_CENTER))]
 
         # A GridSizer will contain the other controls:
@@ -2559,16 +2597,17 @@ class LoadDIDialog(wx.Dialog):
         dlg.Destroy()
         self.Close(True)
 
-class LoadUSGSDialog(wx.Dialog):
+class LoadWebserviceBaselinesDialog(wx.Dialog):
     """
     Dialog for Stream panel
-    Dialog for loading USGS absolutes data.
+    Dialog for loading web service absolutes data.
     """
 
-    def __init__(self, parent, title, stream):
-        super(LoadUSGSDialog, self).__init__(parent=parent,
+    def __init__(self, parent, title, stream, options):
+        super(LoadWebserviceBaselinesDialog, self).__init__(parent=parent,
             title=title, size=(600, 600))
         self.stream = stream
+        self.options = options
         self.urls = []
         self.createControls()
         self.doLayout()
@@ -2576,17 +2615,17 @@ class LoadUSGSDialog(wx.Dialog):
 
     # Widgets
     def createControls(self):
-        dateinfo = ('Specify a date range of absolutes data to be obtain from the'
-                ' USGS absolutes web service. The start and end dates should'
+        dateinfo = ('Specify a date range of absolutes data to be obtain from'
+                ' an absolutes web service. The start and end dates should'
                 ' encompass the plotted data. Note: the default start and end'
                 ' dates correspond to thhe beginning and end of the plotted'
                 ' data.')
         extension_options = ['0 days', '1 day', '2 days', '3 days', '4 days',
                 '5 days', '6 days', '1 week', '2 weeks',  '3 weeks',
                 '4 weeks', '8 weeks']
-        extinfo = ('Extending the beginning and end of the time range will ensure'
-                ' that the scalar and variometer data is covered by the available'
-                ' baseline data. (3 days recommended)')
+        extinfo = ('Extending the beginning and end of the time range will '
+                'ensure that the scalar and variometer data is covered by '
+                'the available baseline data. (3 days recommended)')
         starttime = self.stream.ndarray[KEYLIST.index('time')][0]
         endtime = self.stream.ndarray[KEYLIST.index('time')][-1]
         starttime = num2date(starttime)
@@ -2595,19 +2634,37 @@ class LoadUSGSDialog(wx.Dialog):
         end = wx.DateTimeFromTimeT(time.mktime(endtime.timetuple()))
         self.starttime = starttime
         self.endtime = endtime
-        self.dateInfoText = wx.StaticText(self,-1,dateinfo,size=(500,65))
-        self.startText = wx.StaticText(self,-1,"Start Date:",size=(500,15))
-        self.startDatePicker = wx.DatePickerCtrl(self, dt=start,size=(500,25))
-        self.endText = wx.StaticText(self,-1,"End Date:",size=(500,15))
-        self.endDatePicker = wx.DatePickerCtrl(self, dt=end,size=(500,25))
-        self.extensionText = wx.StaticText(self,-1,"Extension amount:",size=(500,15))
-        self.extInfoText = wx.StaticText(self,-1,extinfo,size=(500,35))
+        self.base = self.options.get('baselinebase','')
+        self.measurements = True
+        self.baseLabel = wx.StaticText(self, -1, "Base URL for web service",
+                size=(500, 15))
+        self.baseTextCtrl = wx.TextCtrl(self, -1, self.base, size=(500, 25))
+        self.dateInfoText = wx.StaticText(self, -1, dateinfo, size=(500, 65))
+        self.startText = wx.StaticText(self, -1, "Start Date:",
+                size=(500, 15))
+        self.startDatePicker = wx.DatePickerCtrl(self, dt=start,
+                size=(500, 25))
+        self.endText = wx.StaticText(self, -1, "End Date:", size=(500, 15))
+        self.endDatePicker = wx.DatePickerCtrl(self, dt=end, size=(500, 25))
+        self.extensionText = wx.StaticText(self, -1, "Extension amount:",
+                size=(500, 15))
+        self.extInfoText = wx.StaticText(self, -1, extinfo, size=(500, 35))
         self.extensionComboBox = wx.Choice(self, choices=extension_options,
-            style=wx.CB_READONLY,size=(500,-1))
-        self.analyzeCheckBox = wx.CheckBox(self, label='Run Analysis Automatically',size=(500,25))
-        self.closeButton = wx.Button(self, wx.ID_CANCEL, label='Cancel',size=(500,25))
-        self.okButton = wx.Button(self, wx.ID_OK, label='Ok',size=(500,25))
+            style=wx.CB_READONLY, size=(500, -1))
+        self.analyzeCheckBox = wx.CheckBox(self,
+                label='Run Analysis Automatically', size=(500, 25))
+        self.includemeasurementsCheckBox = wx.CheckBox(self,
+                label='Include Measurements (Required for USGS baselines.)',
+                size=(500, 25))
+        self.jsonFormatCheckBox = wx.CheckBox(self,
+                label='JSON formatted data (Required for USGS baselines.)',
+                size=(500, 25))
+        self.closeButton = wx.Button(self, wx.ID_CANCEL,
+                label='Cancel', size=(500, 25))
+        self.okButton = wx.Button(self, wx.ID_OK, label='Ok', size=(500, 25))
         self.analyzeCheckBox.SetValue(True)
+        self.includemeasurementsCheckBox.SetValue(True)
+        self.jsonFormatCheckBox.SetValue(True)
 
     def doLayout(self):
         # A horizontal BoxSizer will contain the GridSizer (on the left)
@@ -2621,6 +2678,8 @@ class LoadUSGSDialog(wx.Dialog):
 
         # Add the controls to the sizers:
         controls = [(self.dateInfoText, noOptions),
+                (self.baseLabel, noOptions),
+                (self.baseTextCtrl, dict(flag=wx.ALIGN_CENTER)),
                 (self.startText, noOptions),
                 (self.startDatePicker, dict(flag=wx.ALIGN_CENTER)),
                 (self.endText, noOptions),
@@ -2630,6 +2689,8 @@ class LoadUSGSDialog(wx.Dialog):
                 (self.extInfoText, noOptions),
                 (self.extensionText, noOptions),
                 (self.extensionComboBox,  dict(flag=wx.ALIGN_CENTER)),
+                (self.includemeasurementsCheckBox, dict(flag=wx.ALIGN_CENTER)),
+                (self.jsonFormatCheckBox, dict(flag=wx.ALIGN_CENTER)),
                 (self.analyzeCheckBox, dict(flag=wx.ALIGN_CENTER)),
                 emptySpace,
                 emptySpace,
@@ -2654,6 +2715,10 @@ class LoadUSGSDialog(wx.Dialog):
         self.extensionComboBox.Bind(wx.EVT_CHOICE, self.onExtend)
         self.startDatePicker.Bind(wx.EVT_DATE_CHANGED, self.onChangeDate)
         self.endDatePicker.Bind(wx.EVT_DATE_CHANGED, self.onChangeDate)
+        self.baseTextCtrl.Bind(wx.EVT_TEXT, self.onChangeBase)
+
+    def onChangeBase(self, e):
+        self.base = self.baseTextCtrl.GetValue()
 
     def onChangeDate(self, e):
         starttime = self.startDatePicker.GetValue()

--- a/magpy/gui/dialogclasses.py
+++ b/magpy/gui/dialogclasses.py
@@ -2605,11 +2605,11 @@ class LoadWebserviceBaselinesDialog(wx.Dialog):
     Dialog for loading web service absolutes data.
     """
 
-    def __init__(self, parent, title, stream, options):
+    def __init__(self, parent, title, stream, base):
         super(LoadWebserviceBaselinesDialog, self).__init__(parent=parent,
             title=title, size=(600, 600))
         self.stream = stream
-        self.options = options
+        self.base = base
         self.urls = []
         self.createControls()
         self.doLayout()
@@ -2636,7 +2636,6 @@ class LoadWebserviceBaselinesDialog(wx.Dialog):
         end = wx.DateTimeFromTimeT(time.mktime(endtime.timetuple()))
         self.starttime = starttime
         self.endtime = endtime
-        self.base = self.options.get('baselinebase','')
         self.measurements = True
         self.baseLabel = wx.StaticText(self, -1, "Base URL for web service",
                 size=(500, 15))

--- a/magpy/gui/dialogclasses.py
+++ b/magpy/gui/dialogclasses.py
@@ -243,6 +243,8 @@ class ConnectWebServiceDialog(wx.Dialog):
 
     def createUrl(self):
         base = self.getBaseUrl()
+        if base[-1] != '?':
+            base = base + '?'
         datatype = self.getDataType()
         elements = self.getElements()
         endtime = self.getEndTime()
@@ -797,12 +799,12 @@ class OptionsInitDialog(wx.Dialog):
         self.dirnameTextCtrl = wx.TextCtrl(self,
                 value=self.options.get('dirname', ''), size=(160, 30))
         self.webserviceURLLabel = wx.StaticText(self,
-                label="Default intermagnet webservice baselines URL",
+                label="Default intermagnet webservice URL",
                 size=(160, 35))
         self.webserviceURLTextCtrl = wx.TextCtrl(self, value=webservice,
                 size=(160, 30))
         self.webserviceBaselinesLabel = wx.StaticText(self,
-                label="Default baseline webservice base URL", size=(160, 35))
+                label="Default baseline webservice URL", size=(160, 35))
         self.webserviceBaselinesTextCtrl = wx.TextCtrl(self,
                 value=self.options.get('baselinebase',''), size=(160, 30))
         self.stationidLabel = wx.StaticText(self, label="Station ID",

--- a/magpy/gui/magpy_gui.py
+++ b/magpy/gui/magpy_gui.py
@@ -1976,6 +1976,12 @@ Suite 330, Boston, MA  02111-1307  USA"""
         types = self.options.get('edgetype',[])
         formats = self.options.get('edgeformat',[])
         base = self.options.get('intermagnetbase','')
+        if base == '':
+            base = 'https://geomag.usgs.gov/ws/edge/?'
+            self.options['intermagnetbase'] = base
+            saveini(self.options)
+            inipara, check = loadini()
+            self.initParameter(inipara)
         dlg = ConnectWebServiceDialog(None,
                 title='Create and Open URL for a Web Service', ids=ids,
                 types=types, formats=formats, base=base)
@@ -5231,9 +5237,15 @@ Suite 330, Boston, MA  02111-1307  USA"""
         self.options['dialpha'] = dlg.alphaTextCtrl.GetValue()
         self.options['dideltaF'] = dlg.deltaFTextCtrl.GetValue()
         self.options['diexpI']=''
-        dlg.Destroy()
+        base = self.options.get('baselinebase', '')
+        if base == '':
+            base = 'https://geomag.usgs.gov/baselines/observation.json.php?'
+            self.options['baselinebase'] = base
+            saveini(self.options)
+            inipara, check = loadini()
+            self.initParameter(inipara)
         dlg = LoadWebserviceBaselinesDialog(None, title='Get Webservice Data',
-                stream=self.plotstream, options=self.options)
+                stream=self.plotstream, base=base)
         if dlg.ShowModal() == wx.ID_OK:
             starttime = dlg.starttime
             endtime = dlg.endtime

--- a/magpy/stream.py
+++ b/magpy/stream.py
@@ -10329,8 +10329,9 @@ def read(path_or_url=None, dataformat=None, headonly=False, **kwargs):
                 logger.error("read: No file matching file pattern: %s" % pathname)
                 raise Exception("Cannot read non-existent file!")
             elif not has_magic(pathname) and not os.path.isfile(pathname):
-                logger.error("read: No such file or directory: %s" % pathname)
-                raise Exception("Cannot read non-existent file!")
+                if "&" not in pathname and "=" not in pathname:
+                    logger.error("read: No such file or directory: %s" % pathname)
+                    raise Exception("Cannot read non-existent file!")
             # Only raise error if no starttime/endtime has been set. This
             # will return an empty stream if the user chose a time window with
             # no data in it.
@@ -10421,7 +10422,7 @@ def _read(filename, dataformat=None, headonly=False, **kwargs):
 
 def readWebServiceData(path_or_url, starttime, endtime, elements,
         sampling_period, samplelimit):
-    """Get timeseries data from a webservice.
+    """Get timeseries data from a web service.
         Can be used to circumvent sample limits for data requested from a
         web service.
         Parameters


### PR DESCRIPTION
This pull request allows the user to specify their own web service for retrieving baselines (assuming that startime= and endtime= is used for setting start and end times). There is also an option to set defaults for the intermagnet web service connection and baselines so that they will not default to USGS web services. 